### PR TITLE
Preserve v prefix for Go versions

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -181,7 +181,7 @@ func (p *Parser) parseConstraints(constraintsStr, scheme string) (*Range, error)
 			continue
 		}
 
-		constraint, err := ParseConstraint(part)
+		constraint, err := parseConstraintWithScheme(part, scheme)
 		if err != nil {
 			return nil, err
 		}
@@ -630,7 +630,7 @@ func (p *Parser) parseGoRange(s string) (*Range, error) {
 		parts := strings.Split(s, ",")
 		var result *Range
 		for _, part := range parts {
-			constraint, err := ParseConstraint(strings.TrimSpace(part))
+			constraint, err := parseConstraintWithScheme(strings.TrimSpace(part), "go")
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Go module versions canonically use the v prefix (e.g., v1.0.0). This fix preserves the v prefix when parsing Go version constraints instead of stripping it.

This fixes compatibility with purl which expects Go versions to retain their v prefix.