### PR TITLE
Add golangci-lint config with goconst.ignore-tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+linters:
+  settings:
+    goconst:
+      ignore-tests: true


### PR DESCRIPTION
Test tables tend to repeat literal version strings and package names across independent cases, and extracting those into shared constants makes assertions harder to read. Set goconst to skip test files so the linter stays useful for production code without that noise.