### PR TITLE
Add PEP 440 version comparison for pypi scheme

### DIFF
--- a/interval.go
+++ b/interval.go
@@ -115,7 +115,11 @@ func (i Interval) containsCmp(version string, cmp func(a, b string) int) bool {
 
 // Intersect returns the intersection of two intervals.
 func (i Interval) Intersect(other Interval) Interval {
-	if i.IsEmpty() || other.IsEmpty() {
+	return i.intersectCmp(other, CompareVersions)
+}
+
+func (i Interval) intersectCmp(other Interval, cmp func(a, b string) int) Interval {
+	if i.isEmptyCmp(cmp) || other.isEmptyCmp(cmp) {
 		return EmptyInterval()
 	}
 
@@ -124,12 +128,12 @@ func (i Interval) Intersect(other Interval) Interval {
 	// Determine new minimum
 	switch {
 	case i.Min != "" && other.Min != "":
-		cmp := CompareVersions(i.Min, other.Min)
+		c := cmp(i.Min, other.Min)
 		switch {
-		case cmp > 0:
+		case c > 0:
 			result.Min = i.Min
 			result.MinInclusive = i.MinInclusive
-		case cmp < 0:
+		case c < 0:
 			result.Min = other.Min
 			result.MinInclusive = other.MinInclusive
 		default:
@@ -147,12 +151,12 @@ func (i Interval) Intersect(other Interval) Interval {
 	// Determine new maximum
 	switch {
 	case i.Max != "" && other.Max != "":
-		cmp := CompareVersions(i.Max, other.Max)
+		c := cmp(i.Max, other.Max)
 		switch {
-		case cmp < 0:
+		case c < 0:
 			result.Max = i.Max
 			result.MaxInclusive = i.MaxInclusive
-		case cmp > 0:
+		case c > 0:
 			result.Max = other.Max
 			result.MaxInclusive = other.MaxInclusive
 		default:
@@ -172,23 +176,31 @@ func (i Interval) Intersect(other Interval) Interval {
 
 // Overlaps returns true if the two intervals overlap.
 func (i Interval) Overlaps(other Interval) bool {
-	if i.IsEmpty() || other.IsEmpty() {
+	return i.overlapsCmp(other, CompareVersions)
+}
+
+func (i Interval) overlapsCmp(other Interval, cmp func(a, b string) int) bool {
+	if i.isEmptyCmp(cmp) || other.isEmptyCmp(cmp) {
 		return false
 	}
-	return !i.Intersect(other).IsEmpty()
+	return !i.intersectCmp(other, cmp).isEmptyCmp(cmp)
 }
 
 // Adjacent returns true if the two intervals are adjacent (can be merged).
 func (i Interval) Adjacent(other Interval) bool {
-	if i.IsEmpty() || other.IsEmpty() {
+	return i.adjacentCmp(other, CompareVersions)
+}
+
+func (i Interval) adjacentCmp(other Interval, cmp func(a, b string) int) bool {
+	if i.isEmptyCmp(cmp) || other.isEmptyCmp(cmp) {
 		return false
 	}
 
-	if i.Max != "" && other.Min != "" && CompareVersions(i.Max, other.Min) == 0 {
+	if i.Max != "" && other.Min != "" && cmp(i.Max, other.Min) == 0 {
 		return (i.MaxInclusive && !other.MinInclusive) || (!i.MaxInclusive && other.MinInclusive)
 	}
 
-	if i.Min != "" && other.Max != "" && CompareVersions(i.Min, other.Max) == 0 {
+	if i.Min != "" && other.Max != "" && cmp(i.Min, other.Max) == 0 {
 		return (i.MinInclusive && !other.MaxInclusive) || (!i.MinInclusive && other.MaxInclusive)
 	}
 
@@ -197,14 +209,18 @@ func (i Interval) Adjacent(other Interval) bool {
 
 // Union returns the union of two intervals, or nil if they cannot be merged.
 func (i Interval) Union(other Interval) *Interval {
-	if i.IsEmpty() {
+	return i.unionCmp(other, CompareVersions)
+}
+
+func (i Interval) unionCmp(other Interval, cmp func(a, b string) int) *Interval {
+	if i.isEmptyCmp(cmp) {
 		return &other
 	}
-	if other.IsEmpty() {
+	if other.isEmptyCmp(cmp) {
 		return &i
 	}
 
-	if !i.Overlaps(other) && !i.Adjacent(other) {
+	if !i.overlapsCmp(other, cmp) && !i.adjacentCmp(other, cmp) {
 		return nil
 	}
 
@@ -215,12 +231,12 @@ func (i Interval) Union(other Interval) *Interval {
 		result.Min = ""
 		result.MinInclusive = false
 	} else {
-		cmp := CompareVersions(i.Min, other.Min)
+		c := cmp(i.Min, other.Min)
 		switch {
-		case cmp < 0:
+		case c < 0:
 			result.Min = i.Min
 			result.MinInclusive = i.MinInclusive
-		case cmp > 0:
+		case c > 0:
 			result.Min = other.Min
 			result.MinInclusive = other.MinInclusive
 		default:
@@ -234,12 +250,12 @@ func (i Interval) Union(other Interval) *Interval {
 		result.Max = ""
 		result.MaxInclusive = false
 	} else {
-		cmp := CompareVersions(i.Max, other.Max)
+		c := cmp(i.Max, other.Max)
 		switch {
-		case cmp > 0:
+		case c > 0:
 			result.Max = i.Max
 			result.MaxInclusive = i.MaxInclusive
-		case cmp < 0:
+		case c < 0:
 			result.Max = other.Max
 			result.MaxInclusive = other.MaxInclusive
 		default:

--- a/interval.go
+++ b/interval.go
@@ -48,12 +48,16 @@ func LessThanInterval(version string, inclusive bool) Interval {
 
 // IsEmpty returns true if this interval matches no versions.
 func (i Interval) IsEmpty() bool {
+	return i.isEmptyCmp(CompareVersions)
+}
+
+func (i Interval) isEmptyCmp(cmp func(a, b string) int) bool {
 	if i.Min != "" && i.Max != "" {
-		cmp := CompareVersions(i.Min, i.Max)
-		if cmp > 0 {
+		c := cmp(i.Min, i.Max)
+		if c > 0 {
 			return true
 		}
-		if cmp == 0 && (!i.MinInclusive || !i.MaxInclusive) {
+		if c == 0 && (!i.MinInclusive || !i.MaxInclusive) {
 			return true
 		}
 	}
@@ -67,7 +71,11 @@ func (i Interval) IsUnbounded() bool {
 
 // Contains checks if the interval contains the given version.
 func (i Interval) Contains(version string) bool {
-	if i.IsEmpty() {
+	return i.containsCmp(version, CompareVersions)
+}
+
+func (i Interval) containsCmp(version string, cmp func(a, b string) int) bool {
+	if i.isEmptyCmp(cmp) {
 		return false
 	}
 	if i.IsUnbounded() {
@@ -76,13 +84,13 @@ func (i Interval) Contains(version string) bool {
 
 	// Check minimum bound
 	if i.Min != "" {
-		cmp := CompareVersions(version, i.Min)
+		c := cmp(version, i.Min)
 		if i.MinInclusive {
-			if cmp < 0 {
+			if c < 0 {
 				return false
 			}
 		} else {
-			if cmp <= 0 {
+			if c <= 0 {
 				return false
 			}
 		}
@@ -90,13 +98,13 @@ func (i Interval) Contains(version string) bool {
 
 	// Check maximum bound
 	if i.Max != "" {
-		cmp := CompareVersions(version, i.Max)
+		c := cmp(version, i.Max)
 		if i.MaxInclusive {
-			if cmp > 0 {
+			if c > 0 {
 				return false
 			}
 		} else {
-			if cmp >= 0 {
+			if c >= 0 {
 				return false
 			}
 		}

--- a/parser.go
+++ b/parser.go
@@ -585,17 +585,27 @@ func (p *Parser) parsePessimisticRange(version string) (*Range, error) {
 func (p *Parser) parsePypiRange(s string) (*Range, error) {
 	s = strings.TrimSpace(s)
 
+	// Comma is AND in PEP 440: parse each specifier and intersect.
+	if strings.Contains(s, ",") {
+		var result *Range
+		for _, part := range strings.Split(s, ",") {
+			r, err := p.parsePypiRange(part)
+			if err != nil {
+				return nil, err
+			}
+			if result == nil {
+				result = r
+			} else {
+				result = result.Intersect(r)
+			}
+		}
+		return result, nil
+	}
+
 	// Compatible release: ~=1.4.2
 	if strings.HasPrefix(s, "~=") {
 		version := strings.TrimSpace(s[2:])
 		return p.parsePypiCompatibleRelease(version)
-	}
-
-	// Comma-separated constraints
-	if strings.Contains(s, ",") {
-		parts := strings.Split(s, ",")
-		constraintStr := strings.Join(parts, "|")
-		return p.parseConstraints(constraintStr, "pypi")
 	}
 
 	return p.parseConstraints(s, "pypi")

--- a/parser.go
+++ b/parser.go
@@ -308,7 +308,7 @@ func (p *Parser) parseNpmRange(s string) (*Range, error) {
 			}
 		}
 		return &Range{
-			Intervals:      mergeIntervals(allIntervals),
+			Intervals:      mergeIntervals(allIntervals, CompareVersions),
 			Exclusions:     allExclusions,
 			RawConstraints: allRaw,
 		}, nil
@@ -714,7 +714,7 @@ func (p *Parser) parseHexRange(s string) (*Range, error) {
 			}
 		}
 		return &Range{
-			Intervals:      mergeIntervals(allIntervals),
+			Intervals:      mergeIntervals(allIntervals, CompareVersions),
 			RawConstraints: allRaw,
 		}, nil
 	}

--- a/parser.go
+++ b/parser.go
@@ -588,7 +588,7 @@ func (p *Parser) parsePypiRange(s string) (*Range, error) {
 	// Compatible release: ~=1.4.2
 	if strings.HasPrefix(s, "~=") {
 		version := strings.TrimSpace(s[2:])
-		return p.parsePessimisticRange(version)
+		return p.parsePypiCompatibleRelease(version)
 	}
 
 	// Comma-separated constraints
@@ -599,6 +599,19 @@ func (p *Parser) parsePypiRange(s string) (*Range, error) {
 	}
 
 	return p.parseConstraints(s, "pypi")
+}
+
+// parsePypiCompatibleRelease handles PEP 440 ~= by deriving the upper bound
+// from release segments (ignoring pre/post/dev) and preserving the epoch.
+func (p *Parser) parsePypiCompatibleRelease(version string) (*Range, error) {
+	upper, ok := pep440CompatibleUpper(version)
+	if !ok {
+		// Fall back to the generic pessimistic algorithm when the
+		// version is not valid PEP 440 or has fewer than two release
+		// segments.
+		return p.parsePessimisticRange(version)
+	}
+	return NewRange([]Interval{NewInterval(version, upper, true, false)}), nil
 }
 
 // maven: [1.0,2.0), (1.0,2.0], [1.0,)

--- a/parser.go
+++ b/parser.go
@@ -28,7 +28,9 @@ func (p *Parser) Parse(versURI string) (*Range, error) {
 
 	// Handle wildcard for unbounded range
 	if constraintsStr == "*" || constraintsStr == "" {
-		return Unbounded(), nil
+		r := Unbounded()
+		r.Scheme = scheme
+		return r, nil
 	}
 
 	return p.parseConstraints(constraintsStr, scheme)
@@ -36,6 +38,14 @@ func (p *Parser) Parse(versURI string) (*Range, error) {
 
 // ParseNative parses a native package manager version range into a Range.
 func (p *Parser) ParseNative(constraint string, scheme string) (*Range, error) {
+	r, err := p.parseNative(constraint, scheme)
+	if r != nil && r.Scheme == "" {
+		r.Scheme = scheme
+	}
+	return r, err
+}
+
+func (p *Parser) parseNative(constraint string, scheme string) (*Range, error) {
 	switch scheme {
 	case "npm":
 		return p.parseNpmRange(constraint)

--- a/parser.go
+++ b/parser.go
@@ -51,7 +51,7 @@ func (p *Parser) parseNative(constraint string, scheme string) (*Range, error) {
 		return p.parseNpmRange(constraint)
 	case "gem", "rubygems":
 		return p.parseGemRange(constraint)
-	case "pypi":
+	case "pypi": //nolint:goconst
 		return p.parsePypiRange(constraint)
 	case "maven":
 		return p.parseMavenRange(constraint)
@@ -615,13 +615,21 @@ func (p *Parser) parsePypiRange(s string) (*Range, error) {
 // from release segments (ignoring pre/post/dev) and preserving the epoch.
 func (p *Parser) parsePypiCompatibleRelease(version string) (*Range, error) {
 	upper, ok := pep440CompatibleUpper(version)
-	if !ok {
+	var r *Range
+	if ok {
+		r = NewRange([]Interval{NewInterval(version, upper, true, false)})
+	} else {
 		// Fall back to the generic pessimistic algorithm when the
 		// version is not valid PEP 440 or has fewer than two release
 		// segments.
-		return p.parsePessimisticRange(version)
+		var err error
+		r, err = p.parsePessimisticRange(version)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return NewRange([]Interval{NewInterval(version, upper, true, false)}), nil
+	r.Scheme = "pypi" //nolint:goconst
+	return r, nil
 }
 
 // maven: [1.0,2.0), (1.0,2.0], [1.0,)

--- a/parser.go
+++ b/parser.go
@@ -215,7 +215,7 @@ func (p *Parser) parseConstraints(constraintsStr, scheme string) (*Range, error)
 
 	// Collect all intervals - they form a union
 	// Then intersect overlapping intervals to form proper ranges
-	result := intersectConsecutiveIntervals(intervals)
+	result := intersectConsecutiveIntervals(intervals, scheme)
 
 	// If we only have exclusions and no other constraints, start with unbounded range
 	if result == nil {
@@ -226,19 +226,22 @@ func (p *Parser) parseConstraints(constraintsStr, scheme string) (*Range, error)
 		}
 	}
 	result.Exclusions = exclusions
+	result.Scheme = scheme
 	return result, nil
 }
 
 // intersectConsecutiveIntervals handles VERS constraint semantics:
 // - Consecutive unbounded intervals (like >=X followed by <Y) are intersected to form a range
 // - Bounded intervals (exact versions) are unioned
-func intersectConsecutiveIntervals(intervals []Interval) *Range {
+func intersectConsecutiveIntervals(intervals []Interval, scheme string) *Range {
 	if len(intervals) == 0 {
 		return nil
 	}
 	if len(intervals) == 1 {
 		return NewRange(intervals)
 	}
+
+	cmp := compareFuncFor(scheme)
 
 	var resultIntervals []Interval
 	i := 0
@@ -252,7 +255,7 @@ func intersectConsecutiveIntervals(intervals []Interval) *Range {
 			if (current.Min != "" && current.Max == "" && next.Max != "" && next.Min == "") ||
 				(current.Max != "" && current.Min == "" && next.Min != "" && next.Max == "") {
 				intersection := current.Intersect(next)
-				if !intersection.IsEmpty() {
+				if !intersection.isEmptyCmp(cmp) {
 					resultIntervals = append(resultIntervals, intersection)
 					i += 2
 					continue

--- a/pypi.go
+++ b/pypi.go
@@ -1,0 +1,218 @@
+package vers
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// PEP 440 version parsing and comparison.
+// https://peps.python.org/pep-0440/
+//
+// Version form: [N!]N(.N)*[{a|b|rc}N][.postN][.devN][+local]
+// Ordering: .devN < aN < bN < rcN < (release) < .postN
+
+// pep440Regex is derived from the canonical regex in PEP 440 Appendix B,
+// simplified to the parts we need for ordering.
+var pep440Regex = regexp.MustCompile(`(?i)^\s*v?` +
+	`(?:(\d+)!)?` + // 1: epoch
+	`(\d+(?:\.\d+)*)` + // 2: release
+	`(?:[-_.]?(alpha|beta|preview|pre|rc|a|b|c)[-_.]?(\d*))?` + // 3,4: pre
+	`(?:(?:[-_.]?(post|rev|r)[-_.]?(\d*))|(?:-(\d+)))?` + // 5,6,7: post (or -N implicit post)
+	`(?:[-_.]?(dev)[-_.]?(\d*))?` + // 8,9: dev
+	`(?:\+([a-z0-9]+(?:[-_.][a-z0-9]+)*))?` + // 10: local
+	`\s*$`)
+
+const (
+	pep440NegInf = -1
+	pep440PosInf = 1 << 30 //nolint:mnd
+)
+
+//nolint:goconst,mnd
+var pep440PreTags = map[string]int{
+	"a": 0, "alpha": 0,
+	"b": 1, "beta": 1,
+	"c": 2, "rc": 2, "pre": 2, "preview": 2,
+}
+
+type pep440Version struct {
+	epoch   int
+	release []int
+	preTag  int // pep440NegInf, pep440PosInf, or 0/1/2
+	preNum  int
+	post    int // pep440NegInf or post number
+	dev     int // pep440PosInf or dev number
+	local   []pep440LocalPart
+}
+
+type pep440LocalPart struct {
+	num   int
+	str   string
+	isNum bool
+}
+
+func parsePEP440(s string) (pep440Version, bool) {
+	m := pep440Regex.FindStringSubmatch(s)
+	if m == nil {
+		return pep440Version{}, false
+	}
+
+	v := pep440Version{
+		preTag: pep440PosInf,
+		post:   pep440NegInf,
+		dev:    pep440PosInf,
+	}
+
+	if m[1] != "" {
+		v.epoch, _ = strconv.Atoi(m[1])
+	}
+
+	for _, p := range strings.Split(m[2], ".") {
+		n, _ := strconv.Atoi(p)
+		v.release = append(v.release, n)
+	}
+	// Trim trailing zeros so 1.0 == 1.0.0
+	for len(v.release) > 1 && v.release[len(v.release)-1] == 0 {
+		v.release = v.release[:len(v.release)-1]
+	}
+
+	hasPre := m[3] != ""
+	if hasPre {
+		v.preTag = pep440PreTags[strings.ToLower(m[3])]
+		v.preNum, _ = strconv.Atoi(m[4]) // "" -> 0, matches PEP 440 implicit 0
+	}
+
+	hasPost := m[5] != "" || m[7] != ""
+	if hasPost {
+		if m[7] != "" {
+			v.post, _ = strconv.Atoi(m[7])
+		} else {
+			v.post, _ = strconv.Atoi(m[6])
+		}
+	}
+
+	hasDev := m[8] != ""
+	if hasDev {
+		v.dev, _ = strconv.Atoi(m[9])
+	}
+
+	// PEP 440: a version with only .dev (no pre, no post) sorts before
+	// all pre-releases of the same release.
+	if !hasPre && !hasPost && hasDev {
+		v.preTag = pep440NegInf
+	}
+
+	if m[10] != "" {
+		v.local = parsePEP440Local(m[10])
+	}
+
+	return v, true
+}
+
+func parsePEP440Local(s string) []pep440LocalPart {
+	raw := strings.FieldsFunc(strings.ToLower(s), func(r rune) bool {
+		return r == '.' || r == '-' || r == '_'
+	})
+	parts := make([]pep440LocalPart, 0, len(raw))
+	for _, p := range raw {
+		if n, err := strconv.Atoi(p); err == nil {
+			parts = append(parts, pep440LocalPart{num: n, isNum: true})
+		} else {
+			parts = append(parts, pep440LocalPart{str: p})
+		}
+	}
+	return parts
+}
+
+// comparePyPI compares two PEP 440 version strings.
+// Falls back to generic comparison if either side is not valid PEP 440.
+func comparePyPI(a, b string) int {
+	va, okA := parsePEP440(a)
+	vb, okB := parsePEP440(b)
+	if !okA || !okB {
+		return CompareVersions(a, b)
+	}
+
+	if c := cmpInt(va.epoch, vb.epoch); c != 0 {
+		return c
+	}
+	if c := cmpIntSlice(va.release, vb.release); c != 0 {
+		return c
+	}
+	if c := cmpInt(va.preTag, vb.preTag); c != 0 {
+		return c
+	}
+	if c := cmpInt(va.preNum, vb.preNum); c != 0 {
+		return c
+	}
+	if c := cmpInt(va.post, vb.post); c != 0 {
+		return c
+	}
+	if c := cmpInt(va.dev, vb.dev); c != 0 {
+		return c
+	}
+	return cmpPEP440Local(va.local, vb.local)
+}
+
+func cmpIntSlice(a, b []int) int {
+	n := len(a)
+	if len(b) > n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		var x, y int
+		if i < len(a) {
+			x = a[i]
+		}
+		if i < len(b) {
+			y = b[i]
+		}
+		if c := cmpInt(x, y); c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+func cmpPEP440Local(a, b []pep440LocalPart) int {
+	// No local sorts before any local.
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+	if len(a) == 0 {
+		return -1
+	}
+	if len(b) == 0 {
+		return 1
+	}
+	n := len(a)
+	if len(b) > n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if i >= len(a) {
+			return -1
+		}
+		if i >= len(b) {
+			return 1
+		}
+		pa, pb := a[i], b[i]
+		// Numeric segments sort after strings; within kind, natural order.
+		if pa.isNum != pb.isNum {
+			if pa.isNum {
+				return 1
+			}
+			return -1
+		}
+		if pa.isNum {
+			if c := cmpInt(pa.num, pb.num); c != 0 {
+				return c
+			}
+		} else {
+			if c := cmpString(pa.str, pb.str); c != 0 {
+				return c
+			}
+		}
+	}
+	return 0
+}

--- a/pypi.go
+++ b/pypi.go
@@ -59,10 +59,6 @@ func parsePEP440(s string) (pep440Version, bool) {
 	v := pep440Version{epoch: m[1]}
 
 	v.release = strings.Split(m[2], ".")
-	// Trim trailing zeros so 1.0 == 1.0.0
-	for len(v.release) > 1 && cmpNumStr(v.release[len(v.release)-1], "0") == 0 {
-		v.release = v.release[:len(v.release)-1]
-	}
 
 	if m[3] != "" {
 		v.hasPre = true
@@ -89,6 +85,39 @@ func parsePEP440(s string) (pep440Version, bool) {
 	}
 
 	return v, true
+}
+
+// pep440CompatibleUpper returns the exclusive upper bound for a ~= clause.
+// ~= X.Y   -> < (X+1)
+// ~= X.Y.Z -> < X.(Y+1)
+// The bound is derived from release segments only and preserves the epoch.
+func pep440CompatibleUpper(version string) (string, bool) {
+	v, ok := parsePEP440(version)
+	if !ok || len(v.release) < 2 { //nolint:mnd
+		return "", false
+	}
+	head := make([]string, len(v.release)-1)
+	copy(head, v.release[:len(v.release)-1])
+	head[len(head)-1] = incNumStr(head[len(head)-1])
+	upper := strings.Join(head, ".")
+	if cmpNumStr(v.epoch, "0") != 0 {
+		upper = trimLeadingZeros(v.epoch) + "!" + upper
+	}
+	return upper, true
+}
+
+// incNumStr returns the decimal string s+1 for a non-negative integer string.
+func incNumStr(s string) string {
+	s = trimLeadingZeros(s)
+	b := []byte(s)
+	for i := len(b) - 1; i >= 0; i-- {
+		if b[i] < '9' {
+			b[i]++
+			return string(b)
+		}
+		b[i] = '0'
+	}
+	return "1" + string(b)
 }
 
 func parsePEP440Local(s string) []pep440LocalPart {

--- a/pypi.go
+++ b/pypi.go
@@ -23,11 +23,6 @@ var pep440Regex = regexp.MustCompile(`(?i)^\s*v?` +
 	`(?:\+([a-z0-9]+(?:[-_.][a-z0-9]+)*))?` + // 10: local
 	`\s*$`)
 
-const (
-	pep440NegInf = -1
-	pep440PosInf = 1 << 30 //nolint:mnd
-)
-
 //nolint:goconst,mnd
 var pep440PreTags = map[string]int{
 	"a": 0, "alpha": 0,
@@ -38,10 +33,13 @@ var pep440PreTags = map[string]int{
 type pep440Version struct {
 	epoch   int
 	release []int
-	preTag  int // pep440NegInf, pep440PosInf, or 0/1/2
+	hasPre  bool
+	preTag  int
 	preNum  int
-	post    int // pep440NegInf or post number
-	dev     int // pep440PosInf or dev number
+	hasPost bool
+	post    int
+	hasDev  bool
+	dev     int
 	local   []pep440LocalPart
 }
 
@@ -57,11 +55,7 @@ func parsePEP440(s string) (pep440Version, bool) {
 		return pep440Version{}, false
 	}
 
-	v := pep440Version{
-		preTag: pep440PosInf,
-		post:   pep440NegInf,
-		dev:    pep440PosInf,
-	}
+	v := pep440Version{}
 
 	if m[1] != "" {
 		v.epoch, _ = strconv.Atoi(m[1])
@@ -76,14 +70,14 @@ func parsePEP440(s string) (pep440Version, bool) {
 		v.release = v.release[:len(v.release)-1]
 	}
 
-	hasPre := m[3] != ""
-	if hasPre {
+	if m[3] != "" {
+		v.hasPre = true
 		v.preTag = pep440PreTags[strings.ToLower(m[3])]
 		v.preNum, _ = strconv.Atoi(m[4]) // "" -> 0, matches PEP 440 implicit 0
 	}
 
-	hasPost := m[5] != "" || m[7] != ""
-	if hasPost {
+	if m[5] != "" || m[7] != "" {
+		v.hasPost = true
 		if m[7] != "" {
 			v.post, _ = strconv.Atoi(m[7])
 		} else {
@@ -91,15 +85,9 @@ func parsePEP440(s string) (pep440Version, bool) {
 		}
 	}
 
-	hasDev := m[8] != ""
-	if hasDev {
+	if m[8] != "" {
+		v.hasDev = true
 		v.dev, _ = strconv.Atoi(m[9])
-	}
-
-	// PEP 440: a version with only .dev (no pre, no post) sorts before
-	// all pre-releases of the same release.
-	if !hasPre && !hasPost && hasDev {
-		v.preTag = pep440NegInf
 	}
 
 	if m[10] != "" {
@@ -139,19 +127,71 @@ func comparePyPI(a, b string) int {
 	if c := cmpIntSlice(va.release, vb.release); c != 0 {
 		return c
 	}
-	if c := cmpInt(va.preTag, vb.preTag); c != 0 {
+	if c := cmpPEP440Pre(va, vb); c != 0 {
 		return c
 	}
-	if c := cmpInt(va.preNum, vb.preNum); c != 0 {
+	if c := cmpPEP440Post(va, vb); c != 0 {
 		return c
 	}
-	if c := cmpInt(va.post, vb.post); c != 0 {
-		return c
-	}
-	if c := cmpInt(va.dev, vb.dev); c != 0 {
+	if c := cmpPEP440Dev(va, vb); c != 0 {
 		return c
 	}
 	return cmpPEP440Local(va.local, vb.local)
+}
+
+// cmpPEP440Pre orders the pre-release slot. A dev-only version (no pre, no
+// post) sorts before all pre-releases; a version with no pre otherwise sorts
+// after all pre-releases.
+func cmpPEP440Pre(a, b pep440Version) int {
+	ra, rb := pep440PreRank(a), pep440PreRank(b)
+	if ra != rb {
+		return cmpInt(ra, rb)
+	}
+	if !a.hasPre {
+		return 0
+	}
+	if c := cmpInt(a.preTag, b.preTag); c != 0 {
+		return c
+	}
+	return cmpInt(a.preNum, b.preNum)
+}
+
+func pep440PreRank(v pep440Version) int {
+	if !v.hasPre && !v.hasPost && v.hasDev {
+		return -1
+	}
+	if !v.hasPre {
+		return 1
+	}
+	return 0
+}
+
+// cmpPEP440Post orders the post-release slot. Absence sorts before presence.
+func cmpPEP440Post(a, b pep440Version) int {
+	if a.hasPost != b.hasPost {
+		if a.hasPost {
+			return 1
+		}
+		return -1
+	}
+	if !a.hasPost {
+		return 0
+	}
+	return cmpInt(a.post, b.post)
+}
+
+// cmpPEP440Dev orders the dev-release slot. Absence sorts after presence.
+func cmpPEP440Dev(a, b pep440Version) int {
+	if a.hasDev != b.hasDev {
+		if a.hasDev {
+			return -1
+		}
+		return 1
+	}
+	if !a.hasDev {
+		return 0
+	}
+	return cmpInt(a.dev, b.dev)
 }
 
 func cmpIntSlice(a, b []int) int {

--- a/pypi.go
+++ b/pypi.go
@@ -2,7 +2,6 @@ package vers
 
 import (
 	"regexp"
-	"strconv"
 	"strings"
 )
 
@@ -30,22 +29,24 @@ var pep440PreTags = map[string]int{
 	"c": 2, "rc": 2, "pre": 2, "preview": 2,
 }
 
+// Numeric components in PEP 440 are unbounded non-negative integers, so
+// they are stored as digit strings and compared with cmpNumStr rather than
+// converted to int.
 type pep440Version struct {
-	epoch   int
-	release []int
+	epoch   string
+	release []string
 	hasPre  bool
 	preTag  int
-	preNum  int
+	preNum  string
 	hasPost bool
-	post    int
+	post    string
 	hasDev  bool
-	dev     int
+	dev     string
 	local   []pep440LocalPart
 }
 
 type pep440LocalPart struct {
-	num   int
-	str   string
+	s     string
 	isNum bool
 }
 
@@ -55,39 +56,32 @@ func parsePEP440(s string) (pep440Version, bool) {
 		return pep440Version{}, false
 	}
 
-	v := pep440Version{}
+	v := pep440Version{epoch: m[1]}
 
-	if m[1] != "" {
-		v.epoch, _ = strconv.Atoi(m[1])
-	}
-
-	for _, p := range strings.Split(m[2], ".") {
-		n, _ := strconv.Atoi(p)
-		v.release = append(v.release, n)
-	}
+	v.release = strings.Split(m[2], ".")
 	// Trim trailing zeros so 1.0 == 1.0.0
-	for len(v.release) > 1 && v.release[len(v.release)-1] == 0 {
+	for len(v.release) > 1 && cmpNumStr(v.release[len(v.release)-1], "0") == 0 {
 		v.release = v.release[:len(v.release)-1]
 	}
 
 	if m[3] != "" {
 		v.hasPre = true
 		v.preTag = pep440PreTags[strings.ToLower(m[3])]
-		v.preNum, _ = strconv.Atoi(m[4]) // "" -> 0, matches PEP 440 implicit 0
+		v.preNum = m[4]
 	}
 
 	if m[5] != "" || m[7] != "" {
 		v.hasPost = true
 		if m[7] != "" {
-			v.post, _ = strconv.Atoi(m[7])
+			v.post = m[7]
 		} else {
-			v.post, _ = strconv.Atoi(m[6])
+			v.post = m[6]
 		}
 	}
 
 	if m[8] != "" {
 		v.hasDev = true
-		v.dev, _ = strconv.Atoi(m[9])
+		v.dev = m[9]
 	}
 
 	if m[10] != "" {
@@ -103,13 +97,21 @@ func parsePEP440Local(s string) []pep440LocalPart {
 	})
 	parts := make([]pep440LocalPart, 0, len(raw))
 	for _, p := range raw {
-		if n, err := strconv.Atoi(p); err == nil {
-			parts = append(parts, pep440LocalPart{num: n, isNum: true})
-		} else {
-			parts = append(parts, pep440LocalPart{str: p})
-		}
+		parts = append(parts, pep440LocalPart{s: p, isNum: isDigits(p)})
 	}
 	return parts
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // comparePyPI compares two PEP 440 version strings.
@@ -121,10 +123,10 @@ func comparePyPI(a, b string) int {
 		return CompareVersions(a, b)
 	}
 
-	if c := cmpInt(va.epoch, vb.epoch); c != 0 {
+	if c := cmpNumStr(va.epoch, vb.epoch); c != 0 {
 		return c
 	}
-	if c := cmpIntSlice(va.release, vb.release); c != 0 {
+	if c := cmpNumStrSlice(va.release, vb.release); c != 0 {
 		return c
 	}
 	if c := cmpPEP440Pre(va, vb); c != 0 {
@@ -153,7 +155,7 @@ func cmpPEP440Pre(a, b pep440Version) int {
 	if c := cmpInt(a.preTag, b.preTag); c != 0 {
 		return c
 	}
-	return cmpInt(a.preNum, b.preNum)
+	return cmpNumStr(a.preNum, b.preNum)
 }
 
 func pep440PreRank(v pep440Version) int {
@@ -177,7 +179,7 @@ func cmpPEP440Post(a, b pep440Version) int {
 	if !a.hasPost {
 		return 0
 	}
-	return cmpInt(a.post, b.post)
+	return cmpNumStr(a.post, b.post)
 }
 
 // cmpPEP440Dev orders the dev-release slot. Absence sorts after presence.
@@ -191,23 +193,45 @@ func cmpPEP440Dev(a, b pep440Version) int {
 	if !a.hasDev {
 		return 0
 	}
-	return cmpInt(a.dev, b.dev)
+	return cmpNumStr(a.dev, b.dev)
 }
 
-func cmpIntSlice(a, b []int) int {
+// cmpNumStr compares two non-negative integer strings without converting
+// to a fixed-width type. Empty is treated as zero. Leading zeros are ignored.
+func cmpNumStr(a, b string) int {
+	a = trimLeadingZeros(a)
+	b = trimLeadingZeros(b)
+	if len(a) != len(b) {
+		return cmpInt(len(a), len(b))
+	}
+	return cmpString(a, b)
+}
+
+func trimLeadingZeros(s string) string {
+	if s == "" {
+		return "0"
+	}
+	i := 0
+	for i < len(s)-1 && s[i] == '0' {
+		i++
+	}
+	return s[i:]
+}
+
+func cmpNumStrSlice(a, b []string) int {
 	n := len(a)
 	if len(b) > n {
 		n = len(b)
 	}
 	for i := 0; i < n; i++ {
-		var x, y int
+		var x, y string
 		if i < len(a) {
 			x = a[i]
 		}
 		if i < len(b) {
 			y = b[i]
 		}
-		if c := cmpInt(x, y); c != 0 {
+		if c := cmpNumStr(x, y); c != 0 {
 			return c
 		}
 	}
@@ -245,11 +269,11 @@ func cmpPEP440Local(a, b []pep440LocalPart) int {
 			return -1
 		}
 		if pa.isNum {
-			if c := cmpInt(pa.num, pb.num); c != 0 {
+			if c := cmpNumStr(pa.s, pb.s); c != 0 {
 				return c
 			}
 		} else {
-			if c := cmpString(pa.str, pb.str); c != 0 {
+			if c := cmpString(pa.s, pb.s); c != 0 {
 				return c
 			}
 		}

--- a/pypi_test.go
+++ b/pypi_test.go
@@ -424,6 +424,16 @@ func TestPyPICompatibleRelease(t *testing.T) {
 		{"~=1!1.4.5", "1!1.4.6", true},
 		{"~=1!1.4.5", "1!1.5", false},
 		{"~=1!1.4.5", "1.4.6", false},
+		// ~= composed with other comma-separated specifiers (comma is AND)
+		{"~=1.4.2,!=1.4.5", "1.4.5", false},
+		{"~=1.4.2,!=1.4.5", "1.4.6", true},
+		{"~=1.4.2,!=1.4.5", "1.5", false},
+		{">=1.0,~=1.4", "2.0", false},
+		{">=1.0,~=1.4", "1.4", true},
+		{">=1.0,~=1.4", "1.9", true},
+		{"~=1.4, !=1.4.5, <1.4.8", "1.4.6", true},
+		{"~=1.4, !=1.4.5, <1.4.8", "1.4.5", false},
+		{"~=1.4, !=1.4.5, <1.4.8", "1.4.9", false},
 	}
 	for _, tt := range tests {
 		got, err := Satisfies(tt.version, tt.constraint, "pypi")

--- a/pypi_test.go
+++ b/pypi_test.go
@@ -1,0 +1,300 @@
+package vers
+
+import "testing"
+
+// Issue #24: PyPI prerelease versions are mis-parsed (5.2b1 becomes 5.0.0).
+// https://github.com/git-pkgs/vers/issues/24
+
+func TestIssue24Normalize(t *testing.T) {
+	// Normalize is scheme-agnostic so we don't assert an exact PEP 440 form,
+	// only that the prerelease information is not silently dropped.
+	tests := []struct {
+		in       string
+		notEqual string
+	}{
+		{"5.2b1", "5.0.0"},
+		{"1.0a1", "1.0.0"},
+		{"1.0rc1", "1.0.0"},
+		{"1.0.dev1", "1.0.0"},
+		{"1.0.post1", "1.0.0"},
+	}
+	for _, tt := range tests {
+		got, err := Normalize(tt.in)
+		if err != nil {
+			t.Errorf("Normalize(%q) error = %v", tt.in, err)
+			continue
+		}
+		if got == tt.notEqual {
+			t.Errorf("Normalize(%q) = %q, prerelease info was dropped", tt.in, got)
+		}
+	}
+}
+
+func TestIssue24CompareWithScheme(t *testing.T) {
+	if got := CompareWithScheme("5.1", "5.2b1", "pypi"); got != -1 {
+		t.Errorf("CompareWithScheme(5.1, 5.2b1, pypi) = %d, want -1", got)
+	}
+}
+
+func TestIssue24RangeContains(t *testing.T) {
+	r, err := Parse("vers:pypi/<5.2b1|>=5.1")
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+	if r.Contains("6.0.3") {
+		t.Errorf("vers:pypi/<5.2b1|>=5.1 should not contain 6.0.3")
+	}
+	if !r.Contains("5.1") {
+		t.Errorf("vers:pypi/<5.2b1|>=5.1 should contain 5.1")
+	}
+	if !r.Contains("5.2a1") {
+		t.Errorf("vers:pypi/<5.2b1|>=5.1 should contain 5.2a1")
+	}
+	if r.Contains("5.2b1") {
+		t.Errorf("vers:pypi/<5.2b1|>=5.1 should not contain 5.2b1 (exclusive upper bound)")
+	}
+	if r.Contains("5.0") {
+		t.Errorf("vers:pypi/<5.2b1|>=5.1 should not contain 5.0")
+	}
+}
+
+// TestPyPICompareOrdering verifies the ordering example from PEP 440
+// (https://peps.python.org/pep-0440/#summary-of-permitted-suffixes-and-relative-ordering).
+// Each entry must compare strictly less than the one after it.
+func TestPyPICompareOrdering(t *testing.T) {
+	ordered := []string{
+		"1.dev0",
+		"1.0.dev456",
+		"1.0a1",
+		"1.0a2.dev456",
+		"1.0a12.dev456",
+		"1.0a12",
+		"1.0b1.dev456",
+		"1.0b2",
+		"1.0b2.post345.dev456",
+		"1.0b2.post345",
+		"1.0rc1.dev456",
+		"1.0rc1",
+		"1.0",
+		"1.0+abc.5",
+		"1.0+abc.7",
+		"1.0+5",
+		"1.0.post456.dev34",
+		"1.0.post456",
+		"1.1.dev1",
+	}
+	for i := 0; i < len(ordered)-1; i++ {
+		a, b := ordered[i], ordered[i+1]
+		if got := CompareWithScheme(a, b, "pypi"); got != -1 {
+			t.Errorf("CompareWithScheme(%q, %q, pypi) = %d, want -1", a, b, got)
+		}
+		if got := CompareWithScheme(b, a, "pypi"); got != 1 {
+			t.Errorf("CompareWithScheme(%q, %q, pypi) = %d, want 1", b, a, got)
+		}
+	}
+}
+
+// TestPyPICompareEqual verifies PEP 440 normalization: different spellings of
+// the same version compare equal.
+func TestPyPICompareEqual(t *testing.T) {
+	tests := []struct{ a, b string }{
+		// release segment padding
+		{"1", "1.0"},
+		{"1.0", "1.0.0"},
+		{"1.0.0", "1.0.0.0"},
+		// case insensitivity and v prefix
+		{"1.0RC1", "1.0rc1"},
+		{"v1.0", "1.0"},
+		// pre-release separators
+		{"1.1a1", "1.1.a1"},
+		{"1.1a1", "1.1-a1"},
+		{"1.1a1", "1.1_a1"},
+		// pre-release spelling
+		{"1.0a1", "1.0alpha1"},
+		{"1.0b2", "1.0beta2"},
+		{"1.0rc1", "1.0c1"},
+		{"1.0rc1", "1.0pre1"},
+		{"1.0rc1", "1.0preview1"},
+		// implicit pre-release number
+		{"1.2a", "1.2a0"},
+		// post release spelling and separators
+		{"1.0.post1", "1.0-post1"},
+		{"1.0.post1", "1.0post1"},
+		{"1.0.post1", "1.0.rev1"},
+		{"1.0.post1", "1.0.r1"},
+		// implicit post release (bare -N)
+		{"1.0-1", "1.0.post1"},
+		// implicit post release number
+		{"1.0.post", "1.0.post0"},
+		// dev separators
+		{"1.0.dev1", "1.0-dev1"},
+		{"1.0.dev1", "1.0dev1"},
+		// implicit dev number
+		{"1.0.dev", "1.0.dev0"},
+		// leading zeros in release segments
+		{"1.01", "1.1"},
+		{"01.1", "1.1"},
+		// local version separators
+		{"1.0+ubuntu.1", "1.0+ubuntu-1"},
+		{"1.0+ubuntu.1", "1.0+ubuntu_1"},
+		// local version case
+		{"1.0+ABC", "1.0+abc"},
+	}
+	for _, tt := range tests {
+		if got := CompareWithScheme(tt.a, tt.b, "pypi"); got != 0 {
+			t.Errorf("CompareWithScheme(%q, %q, pypi) = %d, want 0", tt.a, tt.b, got)
+		}
+		if got := CompareWithScheme(tt.b, tt.a, "pypi"); got != 0 {
+			t.Errorf("CompareWithScheme(%q, %q, pypi) = %d, want 0", tt.b, tt.a, got)
+		}
+	}
+}
+
+func TestPyPICompareEpoch(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1!1.0", "2.0", 1},
+		{"2!1.0", "1!2.0", 1},
+		{"1.0", "0!1.0", 0},
+		{"1!1.0", "1!1.0.0", 0},
+	}
+	for _, tt := range tests {
+		if got := CompareWithScheme(tt.a, tt.b, "pypi"); got != tt.want {
+			t.Errorf("CompareWithScheme(%q, %q, pypi) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestPyPICompareLocal(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		// no local < any local
+		{"1.0", "1.0+1", -1},
+		// numeric segments compared numerically
+		{"1.0+2", "1.0+10", -1},
+		// numeric segment > string segment
+		{"1.0+abc", "1.0+1", -1},
+		// longer local with matching prefix sorts higher
+		{"1.0+a", "1.0+a.1", -1},
+		// string segments compared lexically
+		{"1.0+a", "1.0+b", -1},
+	}
+	for _, tt := range tests {
+		if got := CompareWithScheme(tt.a, tt.b, "pypi"); got != tt.want {
+			t.Errorf("CompareWithScheme(%q, %q, pypi) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+		if got := CompareWithScheme(tt.b, tt.a, "pypi"); got != -tt.want {
+			t.Errorf("CompareWithScheme(%q, %q, pypi) = %d, want %d", tt.b, tt.a, got, -tt.want)
+		}
+	}
+}
+
+func TestPyPIComparePairs(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		// dev < alpha < beta < rc < release < post
+		{"1.0.dev1", "1.0a1", -1},
+		{"1.0a1", "1.0b1", -1},
+		{"1.0b1", "1.0rc1", -1},
+		{"1.0rc1", "1.0", -1},
+		{"1.0", "1.0.post1", -1},
+		// numeric ordering within each phase
+		{"1.0a2", "1.0a10", -1},
+		{"1.0.post2", "1.0.post10", -1},
+		{"1.0.dev2", "1.0.dev10", -1},
+		// release segment ordering with different lengths
+		{"1.0", "1.0.1", -1},
+		{"1.0.1", "1.1", -1},
+		// pre-release with dev sorts before same pre-release without
+		{"1.0a1.dev1", "1.0a1", -1},
+		// post on a pre-release sorts after that pre-release, before next pre-release
+		{"1.0a1", "1.0a1.post1", -1},
+		{"1.0a1.post1", "1.0a2", -1},
+		// dev-only release sorts before all pre-releases of that release
+		{"1.0.dev1", "1.0rc1", -1},
+		// but after post of the previous release
+		{"0.9.post1", "1.0.dev1", -1},
+	}
+	for _, tt := range tests {
+		if got := CompareWithScheme(tt.a, tt.b, "pypi"); got != tt.want {
+			t.Errorf("CompareWithScheme(%q, %q, pypi) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+		if got := CompareWithScheme(tt.b, tt.a, "pypi"); got != -tt.want {
+			t.Errorf("CompareWithScheme(%q, %q, pypi) = %d, want %d", tt.b, tt.a, got, -tt.want)
+		}
+	}
+}
+
+func TestPyPIRangeContains(t *testing.T) {
+	tests := []struct {
+		versURI string
+		version string
+		want    bool
+	}{
+		// bounded prerelease window
+		{"vers:pypi/>=5.1|<5.2b1", "5.1", true},
+		{"vers:pypi/>=5.1|<5.2b1", "5.1.9", true},
+		{"vers:pypi/>=5.1|<5.2b1", "5.2a1", true},
+		{"vers:pypi/>=5.1|<5.2b1", "5.2b1", false},
+		{"vers:pypi/>=5.1|<5.2b1", "5.2", false},
+		{"vers:pypi/>=5.1|<5.2b1", "6.0.3", false},
+		// constraint order reversed (as in the issue)
+		{"vers:pypi/<5.2b1|>=5.1", "6.0.3", false},
+		{"vers:pypi/<5.2b1|>=5.1", "5.1.5", true},
+		// upper bound is a release, prereleases of that release are inside
+		{"vers:pypi/>=1.0|<2.0", "2.0a1", true},
+		{"vers:pypi/>=1.0|<2.0", "2.0", false},
+		{"vers:pypi/>=1.0|<2.0", "1.0", true},
+		// dev release below lower bound
+		{"vers:pypi/>=1.0|<2.0", "1.0.dev1", false},
+		// post release above upper bound
+		{"vers:pypi/>=1.0|<=2.0", "2.0.post1", false},
+		{"vers:pypi/>=1.0|<=2.0", "2.0", true},
+		// exclusion with PEP 440 equality
+		{"vers:pypi/>=1.0|!=1.5.0|<2.0", "1.5", false},
+		{"vers:pypi/>=1.0|!=1.5.0|<2.0", "1.5.1", true},
+		// epoch in range bound
+		{"vers:pypi/>=1!1.0", "2.0", false},
+		{"vers:pypi/>=1!1.0", "1!1.0", true},
+		{"vers:pypi/>=1!1.0", "1!2.0", true},
+	}
+	for _, tt := range tests {
+		r, err := Parse(tt.versURI)
+		if err != nil {
+			t.Errorf("Parse(%q) error = %v", tt.versURI, err)
+			continue
+		}
+		if got := r.Contains(tt.version); got != tt.want {
+			t.Errorf("Parse(%q).Contains(%q) = %v, want %v", tt.versURI, tt.version, got, tt.want)
+		}
+	}
+}
+
+func TestPyPINativeRangeContains(t *testing.T) {
+	tests := []struct {
+		constraint string
+		version    string
+		want       bool
+	}{
+		{">=5.1,<5.2b1", "5.1.5", true},
+		{">=5.1,<5.2b1", "6.0.3", false},
+		{">=1.0,<2.0", "2.0a1", true},
+		{">=1.0,<2.0", "2.0", false},
+	}
+	for _, tt := range tests {
+		r, err := ParseNative(tt.constraint, "pypi")
+		if err != nil {
+			t.Errorf("ParseNative(%q, pypi) error = %v", tt.constraint, err)
+			continue
+		}
+		if got := r.Contains(tt.version); got != tt.want {
+			t.Errorf("ParseNative(%q, pypi).Contains(%q) = %v, want %v", tt.constraint, tt.version, got, tt.want)
+		}
+	}
+}

--- a/pypi_test.go
+++ b/pypi_test.go
@@ -276,6 +276,80 @@ func TestPyPIRangeContains(t *testing.T) {
 	}
 }
 
+func TestPyPIRangeIsEmpty(t *testing.T) {
+	// [1.0.dev1, 1.0a1) is non-empty under PEP 440 even though generic
+	// comparison would order dev1 > a1.
+	r, err := Parse("vers:pypi/>=1.0.dev1|<1.0a1")
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+	if r.IsEmpty() {
+		t.Errorf("vers:pypi/>=1.0.dev1|<1.0a1 IsEmpty() = true, want false")
+	}
+	if !r.Contains("1.0.dev2") {
+		t.Errorf("vers:pypi/>=1.0.dev1|<1.0a1 should contain 1.0.dev2")
+	}
+	if got := defaultParser.ToVersString(r, "pypi"); got == "vers:pypi/" {
+		t.Errorf("ToVersString serialized non-empty range as %q", got)
+	}
+}
+
+func TestPyPISchemePropagation(t *testing.T) {
+	// ParseNative ~= path
+	ok, err := Satisfies("1.0a1", "~=1.0.dev1", "pypi")
+	if err != nil {
+		t.Fatalf("Satisfies error = %v", err)
+	}
+	if !ok {
+		t.Errorf("Satisfies(1.0a1, ~=1.0.dev1, pypi) = false, want true")
+	}
+
+	// Wildcard
+	r, _ := Parse("vers:pypi/*")
+	if r.Scheme != "pypi" {
+		t.Errorf("Parse(vers:pypi/*).Scheme = %q, want pypi", r.Scheme)
+	}
+
+	// Exclude preserves scheme
+	r, _ = Parse("vers:pypi/>=1.0")
+	r2 := r.Exclude("1.5")
+	if r2.Scheme != "pypi" {
+		t.Errorf("Exclude dropped scheme: got %q", r2.Scheme)
+	}
+	if r2.Contains("1.5.0") {
+		t.Errorf("excluded 1.5 should also exclude 1.5.0 under PEP 440 equality")
+	}
+
+	// Union and Intersect preserve scheme
+	a, _ := Parse("vers:pypi/>=1.0|<2.0")
+	b, _ := Parse("vers:pypi/>=1.5|<3.0")
+	if u := a.Union(b); u.Scheme != "pypi" {
+		t.Errorf("Union dropped scheme: got %q", u.Scheme)
+	}
+	if i := a.Intersect(b); i.Scheme != "pypi" {
+		t.Errorf("Intersect dropped scheme: got %q", i.Scheme)
+	}
+}
+
+func TestPyPICompareLargeNumbers(t *testing.T) {
+	// Numeric components can exceed any fixed sentinel; presence of dev
+	// must still sort before absence regardless of magnitude.
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0a1.dev2000000000", "1.0a1", -1},
+		{"1.0.dev2000000000", "1.0a1", -1},
+		{"1.0", "1.0.post2000000000", -1},
+		{"1.0a2000000000", "1.0", -1},
+	}
+	for _, tt := range tests {
+		if got := CompareWithScheme(tt.a, tt.b, "pypi"); got != tt.want {
+			t.Errorf("CompareWithScheme(%q, %q, pypi) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
 func TestPyPINativeRangeContains(t *testing.T) {
 	tests := []struct {
 		constraint string

--- a/pypi_test.go
+++ b/pypi_test.go
@@ -396,6 +396,62 @@ func TestPyPICompareLargeNumbers(t *testing.T) {
 	}
 }
 
+func TestPyPICompatibleRelease(t *testing.T) {
+	// ~= counts release segments, not dots; pre/post/dev suffixes and
+	// epochs must not affect the derived upper bound.
+	tests := []struct {
+		constraint string
+		version    string
+		want       bool
+	}{
+		// ~=1.4.dev1 -> >=1.4.dev1, <2 (release is 1.4, two segments)
+		{"~=1.4.dev1", "1.4.dev1", true},
+		{"~=1.4.dev1", "1.9", true},
+		{"~=1.4.dev1", "2.0", false},
+		{"~=1.4.dev1", "1.3", false},
+		// ~=1.4.5 -> >=1.4.5, <1.5 (three release segments)
+		{"~=1.4.5", "1.4.6", true},
+		{"~=1.4.5", "1.5", false},
+		// ~=1.4.5.post1 -> >=1.4.5.post1, <1.5 (still three release segments)
+		{"~=1.4.5.post1", "1.4.9", true},
+		{"~=1.4.5.post1", "1.5", false},
+		// trailing-zero release segments still count
+		{"~=2.0.dev1", "2.5", true},
+		{"~=2.0.dev1", "3.0", false},
+		{"~=2.0.0", "2.0.9", true},
+		{"~=2.0.0", "2.1", false},
+		// epoch preserved in the upper bound
+		{"~=1!1.4.5", "1!1.4.6", true},
+		{"~=1!1.4.5", "1!1.5", false},
+		{"~=1!1.4.5", "1.4.6", false},
+	}
+	for _, tt := range tests {
+		got, err := Satisfies(tt.version, tt.constraint, "pypi")
+		if err != nil {
+			t.Errorf("Satisfies(%q, %q, pypi) error = %v", tt.version, tt.constraint, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("Satisfies(%q, %q, pypi) = %v, want %v", tt.version, tt.constraint, got, tt.want)
+		}
+	}
+}
+
+func TestPyPIUnionExclusionEquality(t *testing.T) {
+	a, _ := Parse("vers:pypi/>=1.0|!=1.5|<2.0")
+	b, _ := Parse("vers:pypi/>=1.0|!=1.5.0|<2.0")
+	u := a.Union(b)
+	if u.Contains("1.5") {
+		t.Errorf("union should still exclude 1.5 (both inputs exclude a version equal to it)")
+	}
+	if u.Contains("1.5.0") {
+		t.Errorf("union should still exclude 1.5.0")
+	}
+	if !u.Contains("1.6") {
+		t.Errorf("union should contain 1.6")
+	}
+}
+
 func TestPyPINativeRangeContains(t *testing.T) {
 	tests := []struct {
 		constraint string

--- a/pypi_test.go
+++ b/pypi_test.go
@@ -331,6 +331,43 @@ func TestPyPISchemePropagation(t *testing.T) {
 	}
 }
 
+func TestPyPIRangeAlgebra(t *testing.T) {
+	a, _ := Parse("vers:pypi/>=1.0.dev1")
+	b, _ := Parse("vers:pypi/<1.0a1")
+
+	i := a.Intersect(b)
+	if i.IsEmpty() {
+		t.Errorf("Intersect(>=1.0.dev1, <1.0a1) is empty, want [1.0.dev1, 1.0a1)")
+	}
+	if !i.Contains("1.0.dev2") {
+		t.Errorf("Intersect(>=1.0.dev1, <1.0a1) should contain 1.0.dev2")
+	}
+	if i.Contains("1.0a1") {
+		t.Errorf("Intersect(>=1.0.dev1, <1.0a1) should not contain 1.0a1")
+	}
+
+	// Union of two intervals whose bounds only order correctly under PEP 440
+	// should merge into one.
+	c, _ := Parse("vers:pypi/>=1.0.dev1|<1.0a1")
+	d, _ := Parse("vers:pypi/>=1.0.dev5|<1.0b1")
+	u := c.Union(d)
+	if !u.Contains("1.0.dev2") || !u.Contains("1.0a5") || u.Contains("1.0b1") {
+		t.Errorf("Union of overlapping pypi intervals gave wrong containment: %v", u.Intervals)
+	}
+
+	// Intersect where both sides have a lower bound and PEP 440 disagrees
+	// with generic ordering on which is higher.
+	e, _ := Parse("vers:pypi/>=1.0.dev1|<2.0")
+	f, _ := Parse("vers:pypi/>=1.0a1|<2.0")
+	ef := e.Intersect(f)
+	if ef.Contains("1.0.dev5") {
+		t.Errorf("Intersect should have raised lower bound to 1.0a1")
+	}
+	if !ef.Contains("1.0a1") {
+		t.Errorf("Intersect should contain 1.0a1")
+	}
+}
+
 func TestPyPICompareLargeNumbers(t *testing.T) {
 	// Numeric components can exceed any fixed sentinel; presence of dev
 	// must still sort before absence regardless of magnitude.
@@ -342,6 +379,15 @@ func TestPyPICompareLargeNumbers(t *testing.T) {
 		{"1.0.dev2000000000", "1.0a1", -1},
 		{"1.0", "1.0.post2000000000", -1},
 		{"1.0a2000000000", "1.0", -1},
+		// Values that overflow int must still order distinctly.
+		{"1.0a888888888888888888888888", "1.0a999999999999999999999999", -1},
+		{"1.0.dev888888888888888888888888", "1.0.dev999999999999999999999999", -1},
+		{"1.0.post888888888888888888888888", "1.0.post999999999999999999999999", -1},
+		{"888888888888888888888888!1.0", "999999999999999999999999!1.0", -1},
+		{"1.888888888888888888888888", "1.999999999999999999999999", -1},
+		// Large local numeric segments stay numeric.
+		{"1.0+888888888888888888888888", "1.0+999999999999999999999999", -1},
+		{"1.0+abc", "1.0+888888888888888888888888", -1},
 	}
 	for _, tt := range tests {
 		if got := CompareWithScheme(tt.a, tt.b, "pypi"); got != tt.want {

--- a/pypi_test.go
+++ b/pypi_test.go
@@ -434,6 +434,10 @@ func TestPyPICompatibleRelease(t *testing.T) {
 		{"~=1.4, !=1.4.5, <1.4.8", "1.4.6", true},
 		{"~=1.4, !=1.4.5, <1.4.8", "1.4.5", false},
 		{"~=1.4, !=1.4.5, <1.4.8", "1.4.9", false},
+		// Leading ~= must intersect under pypi rules regardless of order.
+		{"~=1.0.dev1,<1.0a1", "1.0.dev2", true},
+		{"~=1.0.dev1,<1.0a1", "1.0a1", false},
+		{"<1.0a1,~=1.0.dev1", "1.0.dev2", true},
 	}
 	for _, tt := range tests {
 		got, err := Satisfies(tt.version, tt.constraint, "pypi")

--- a/range.go
+++ b/range.go
@@ -48,8 +48,9 @@ func (r *Range) IsEmpty() bool {
 	if len(r.Intervals) == 0 {
 		return true
 	}
+	cmp := compareFuncFor(r.Scheme)
 	for _, interval := range r.Intervals {
-		if !interval.IsEmpty() {
+		if !interval.isEmptyCmp(cmp) {
 			return false
 		}
 	}
@@ -110,7 +111,7 @@ func (r *Range) Union(other *Range) *Range {
 		rawConstraints = append(rawConstraints, other.Intervals...)
 	}
 
-	return &Range{Intervals: merged, Exclusions: exclusions, RawConstraints: rawConstraints}
+	return &Range{Intervals: merged, Exclusions: exclusions, RawConstraints: rawConstraints, Scheme: r.Scheme}
 }
 
 // Intersect returns a new Range that is the intersection of this range and another.
@@ -129,7 +130,7 @@ func (r *Range) Intersect(other *Range) *Range {
 	}
 
 	if r.IsEmpty() || other.IsEmpty() {
-		return &Range{RawConstraints: rawConstraints}
+		return &Range{RawConstraints: rawConstraints, Scheme: r.Scheme}
 	}
 
 	// Intersect each pair of intervals
@@ -162,7 +163,7 @@ func (r *Range) Intersect(other *Range) *Range {
 		}
 	}
 
-	return &Range{Intervals: merged, Exclusions: exclusions, RawConstraints: rawConstraints}
+	return &Range{Intervals: merged, Exclusions: exclusions, RawConstraints: rawConstraints, Scheme: r.Scheme}
 }
 
 // Exclude returns a new Range that excludes the given version.
@@ -174,6 +175,7 @@ func (r *Range) Exclude(version string) *Range {
 	return &Range{
 		Intervals:  r.Intervals,
 		Exclusions: exclusions,
+		Scheme:     r.Scheme,
 	}
 }
 

--- a/range.go
+++ b/range.go
@@ -12,6 +12,9 @@ type Range struct {
 	Exclusions []string // Versions to exclude (from != constraints)
 	// RawConstraints stores the original constraints for VERS output (not merged)
 	RawConstraints []Interval
+	// Scheme is the versioning scheme this range was parsed under.
+	// It selects the comparison rules used by Contains. Empty means generic.
+	Scheme string
 }
 
 // NewRange creates a new Range from intervals.
@@ -21,16 +24,18 @@ func NewRange(intervals []Interval) *Range {
 
 // Contains checks if the range contains the given version.
 func (r *Range) Contains(version string) bool {
+	cmp := compareFuncFor(r.Scheme)
+
 	// Check exclusions first
 	for _, exc := range r.Exclusions {
-		if CompareVersions(version, exc) == 0 {
+		if cmp(version, exc) == 0 {
 			return false
 		}
 	}
 
 	// Check if version is in any interval
 	for _, interval := range r.Intervals {
-		if interval.Contains(version) {
+		if interval.containsCmp(version, cmp) {
 			return true
 		}
 	}

--- a/range.go
+++ b/range.go
@@ -84,14 +84,16 @@ func (r *Range) Union(other *Range) *Range {
 	allIntervals = append(allIntervals, r.Intervals...)
 	allIntervals = append(allIntervals, other.Intervals...)
 
+	cmp := compareFuncFor(r.Scheme)
+
 	// Merge overlapping intervals for containment checking
-	merged := mergeIntervals(allIntervals, compareFuncFor(r.Scheme))
+	merged := mergeIntervals(allIntervals, cmp)
 
 	// Combine exclusions (intersection of exclusions for union)
 	exclusions := make([]string, 0)
 	for _, e := range r.Exclusions {
 		for _, oe := range other.Exclusions {
-			if e == oe {
+			if cmp(e, oe) == 0 {
 				exclusions = append(exclusions, e)
 				break
 			}

--- a/range.go
+++ b/range.go
@@ -85,7 +85,7 @@ func (r *Range) Union(other *Range) *Range {
 	allIntervals = append(allIntervals, other.Intervals...)
 
 	// Merge overlapping intervals for containment checking
-	merged := mergeIntervals(allIntervals)
+	merged := mergeIntervals(allIntervals, compareFuncFor(r.Scheme))
 
 	// Combine exclusions (intersection of exclusions for union)
 	exclusions := make([]string, 0)
@@ -133,19 +133,21 @@ func (r *Range) Intersect(other *Range) *Range {
 		return &Range{RawConstraints: rawConstraints, Scheme: r.Scheme}
 	}
 
+	cmp := compareFuncFor(r.Scheme)
+
 	// Intersect each pair of intervals
 	var result []Interval
 	for _, i1 := range r.Intervals {
 		for _, i2 := range other.Intervals {
-			intersection := i1.Intersect(i2)
-			if !intersection.IsEmpty() {
+			intersection := i1.intersectCmp(i2, cmp)
+			if !intersection.isEmptyCmp(cmp) {
 				result = append(result, intersection)
 			}
 		}
 	}
 
 	// Merge overlapping intervals
-	merged := mergeIntervals(result)
+	merged := mergeIntervals(result, cmp)
 
 	// Combine exclusions (union of exclusions for intersection)
 	exclusions := make([]string, 0, len(r.Exclusions)+len(other.Exclusions))
@@ -203,7 +205,7 @@ func (r *Range) String() string {
 }
 
 // mergeIntervals merges overlapping intervals into a minimal set.
-func mergeIntervals(intervals []Interval) []Interval {
+func mergeIntervals(intervals []Interval, cmp func(a, b string) int) []Interval {
 	if len(intervals) <= 1 {
 		return intervals
 	}
@@ -211,7 +213,7 @@ func mergeIntervals(intervals []Interval) []Interval {
 	// Filter empty intervals and sort by lower bound
 	sorted := make([]Interval, 0, len(intervals))
 	for _, iv := range intervals {
-		if !iv.IsEmpty() {
+		if !iv.isEmptyCmp(cmp) {
 			sorted = append(sorted, iv)
 		}
 	}
@@ -227,9 +229,9 @@ func mergeIntervals(intervals []Interval) []Interval {
 		if a.Min != "" && b.Min == "" {
 			return false
 		}
-		cmp := CompareVersions(a.Min, b.Min)
-		if cmp != 0 {
-			return cmp < 0
+		c := cmp(a.Min, b.Min)
+		if c != 0 {
+			return c < 0
 		}
 		return a.MinInclusive && !b.MinInclusive
 	})
@@ -237,7 +239,7 @@ func mergeIntervals(intervals []Interval) []Interval {
 	result := []Interval{sorted[0]}
 	for _, iv := range sorted[1:] {
 		last := &result[len(result)-1]
-		if union := last.Union(iv); union != nil {
+		if union := last.unionCmp(iv, cmp); union != nil {
 			*last = *union
 		} else {
 			result = append(result, iv)

--- a/version.go
+++ b/version.go
@@ -119,9 +119,9 @@ func parseDotSeparated(v *VersionInfo, s string) *VersionInfo {
 		v.Major, _ = strconv.Atoi(parts[0])
 	}
 	if len(parts) >= 2 && !strings.Contains(parts[1], "-") { //nolint:mnd
-		v.Minor, _ = strconv.Atoi(parts[1])
+		v.Minor, v.Prerelease = splitAlphaSuffix(parts[1])
 	}
-	if len(parts) >= 3 { //nolint:mnd
+	if len(parts) >= 3 && v.Prerelease == "" { //nolint:mnd
 		if strings.Contains(parts[2], "-") {
 			patchParts := strings.SplitN(parts[2], "-", 2) //nolint:mnd
 			v.Patch, _ = strconv.Atoi(patchParts[0])
@@ -129,13 +129,35 @@ func parseDotSeparated(v *VersionInfo, s string) *VersionInfo {
 				v.Prerelease = patchParts[1]
 			}
 		} else {
-			v.Patch, _ = strconv.Atoi(parts[2])
+			v.Patch, v.Prerelease = splitAlphaSuffix(parts[2])
 		}
 	}
 	if len(parts) > 3 && v.Prerelease == "" { //nolint:mnd
 		v.Prerelease = strings.Join(parts[3:], ".")
 	}
 	return v
+}
+
+// splitAlphaSuffix splits a segment into its leading integer and a trailing
+// suffix that starts with a letter. "2b1" -> (2, "b1"), "dev1" -> (0, "dev1"),
+// "5" -> (5, ""). Segments whose non-numeric tail does not start with a letter
+// (e.g. "0|2", "0~rc1") return ("", 0) with the tail dropped, matching the
+// previous behaviour for schemes we don't yet handle here.
+func splitAlphaSuffix(s string) (int, string) {
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	if i < len(s) && isLetter(s[i]) {
+		n, _ := strconv.Atoi(s[:i])
+		return n, s[i:]
+	}
+	n, _ := strconv.Atoi(s)
+	return n, ""
+}
+
+func isLetter(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
 }
 
 // String returns the normalized version string.
@@ -272,13 +294,20 @@ func CompareWithScheme(a, b, scheme string) int {
 		return 1
 	}
 
+	return compareFuncFor(scheme)(a, b)
+}
+
+// compareFuncFor returns the version comparison function for a scheme.
+func compareFuncFor(scheme string) func(a, b string) int {
 	switch scheme {
 	case "nuget": //nolint:goconst
-		return compareNuGet(a, b)
+		return compareNuGet
 	case "maven":
-		return compareMaven(a, b)
+		return compareMaven
+	case "pypi":
+		return comparePyPI
 	default:
-		return CompareVersions(a, b)
+		return CompareVersions
 	}
 }
 
@@ -539,7 +568,7 @@ type mavenComponent struct {
 // Maven qualifier ordering
 // Order: alpha < beta < milestone < rc < snapshot < "" (release) < sp < unknown < numbers
 //
-//nolint:mnd
+//nolint:mnd,goconst
 var mavenQualifierOrder = map[string]int{
 	"alpha":     1,
 	"beta":      2,

--- a/version.go
+++ b/version.go
@@ -304,7 +304,7 @@ func compareFuncFor(scheme string) func(a, b string) int {
 		return compareNuGet
 	case "maven":
 		return compareMaven
-	case "pypi":
+	case "pypi": //nolint:goconst
 		return comparePyPI
 	default:
 		return CompareVersions


### PR DESCRIPTION
Fixes #24.

`parseDotSeparated` silently dropped non-numeric segment suffixes, so `5.2b1` parsed as `5.0.0` and every PEP 440 prerelease form (`a`, `b`, `rc`, `.dev`, `.post`) collapsed to the release. There was also no `pypi` case in `CompareWithScheme`, and `Range.Contains` used generic comparison regardless of scheme, so even a correct comparator would not have been reached.

This adds a PEP 440 comparator (`pypi.go`) covering epoch, release-segment padding, `dev < a < b < rc < release < post` ordering, the spelling and separator variants the spec allows, and local version segments. `Range` now records the scheme it was parsed under and `Contains` dispatches to the matching comparator; `intersectConsecutiveIntervals` uses the same comparator when deciding whether a paired `>=X | <Y` interval is empty, so `[5.1, 5.2b1)` is no longer thrown away. `parseDotSeparated` splits a trailing letter suffix off a segment instead of discarding it, which fixes the generic `Normalize` path.

New tests in `pypi_test.go` cover the three reported cases plus the ordering chain from the PEP 440 spec, normalization equivalences, epochs, local versions, and range containment through both `vers:pypi/` and native syntax.

The scheme-on-`Range` change also means maven and nuget containment now use their own comparators, which fixes a couple of latent cases noted in #25, though the rest of #25 (deb, rpm, gem) is out of scope here.