### PR TITLE
Add ecosystem-specific version handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ r, _ = vers.ParseNative(">> 1.0", "deb")
 
 // RPM
 r, _ = vers.ParseNative(">= 1.0", "rpm")
+
+// Conan, OpenSSL, and Nginx
+r, _ = vers.ParseNative("^1.2", "conan")
+r, _ = vers.ParseNative("1.1.1w, 3.0.0", "openssl")
+r, _ = vers.ParseNative("0.8.40+", "nginx")
 ```
 
 ### Check Version Satisfaction
@@ -89,6 +94,10 @@ vers.Compare("1.0.0", "1.0.0")  // 0  (equal)
 
 // Prerelease versions sort before stable
 vers.Compare("1.0.0", "1.0.0-alpha")  // 1 (stable > prerelease)
+
+// Use ecosystem-specific ordering where versions are not SemVer
+vers.CompareWithScheme("1.0~rc1", "1.0", "deb")  // -1
+vers.CompareWithScheme("1.0.beta1", "1.0", "gem") // -1
 ```
 
 ### Version Validation and Normalization
@@ -100,6 +109,9 @@ vers.Valid("invalid")      // false
 v, _ := vers.Normalize("1")      // "1.0.0"
 v, _ = vers.Normalize("1.2")     // "1.2.0"
 v, _ = vers.Normalize("1.2.3")   // "1.2.3"
+
+vers.ValidWithScheme("1:2.3.4-1", "deb") // true
+v, _ = vers.NormalizeWithScheme("01!02.0RC1", "pypi") // "1!2.0rc1"
 ```
 
 ### Create Ranges Programmatically
@@ -150,8 +162,15 @@ uri = vers.ToVersString(r, "npm")
 | NuGet | `nuget` | Same as Maven |
 | Cargo | `cargo` | Same as npm |
 | Go | `go`, `golang` | `>=1.0.0,<2.0.0` |
+| Hex | `hex`, `elixir` | `~> 1.2`, `>= 1.0 and < 2.0` |
 | Debian | `deb`, `debian` | `>> 1.0`, `<< 2.0`, `>= 1.0` |
 | RPM | `rpm` | `>= 1.0`, `<= 2.0` |
+| Conan | `conan` | `^1.2`, `~1.2`, `>1 <2`, `||` |
+| OpenSSL | `openssl` | `1.1.1w`, `1.1.1w, 3.0.0` |
+| Nginx | `nginx` | `0.8.40+`, `0.7.52-0.8.39` |
+
+Version comparison additionally supports `semver`, `apk`/`alpine`, `alpm`,
+`gentoo`, `intdot`, `lexicographic`, and `datetime`.
 
 ## Development
 

--- a/conformance_test.go
+++ b/conformance_test.go
@@ -34,6 +34,10 @@ type versionCmpInput struct {
 	Versions    []string `json:"versions"`
 }
 
+type roundtripInput struct {
+	Vers string `json:"vers"`
+}
+
 func loadTestFile(t *testing.T, filename string) *versTestFile {
 	t.Helper()
 	path := filepath.Join("testdata", "vers-spec", "tests", filename)
@@ -50,8 +54,12 @@ func loadTestFile(t *testing.T, filename string) *versTestFile {
 
 func TestConformance_FromNative(t *testing.T) {
 	files := []string{
+		"conan_range_from_native_basic_test.json",
+		"conan_range_from_native_test.json",
 		"gem_range_from_native_test.json",
+		"nginx_range_from_native_test.json",
 		"npm_range_from_native_test.json",
+		"openssl_range_from_native_test.json",
 		"pypi_range_from_native_test.json",
 		"nuget_range_from_native_test.json",
 	}
@@ -136,11 +144,45 @@ func TestConformance_Containment(t *testing.T) {
 	}
 }
 
+func TestConformance_RoundTrip(t *testing.T) {
+	tf := loadTestFile(t, "pypi_range_roundtrip_test.json")
+	for _, tc := range tf.Tests {
+		if tc.TestType != "roundtrip" {
+			continue
+		}
+		var input roundtripInput
+		if err := json.Unmarshal(tc.Input, &input); err != nil {
+			t.Errorf("failed to parse input: %v", err)
+			continue
+		}
+		var expected string
+		if err := json.Unmarshal(tc.ExpectedOutput, &expected); err != nil {
+			t.Errorf("failed to parse expected output: %v", err)
+			continue
+		}
+		t.Run(input.Vers, func(t *testing.T) {
+			r, err := Parse(input.Vers)
+			if err != nil {
+				t.Fatalf("Parse(%q) error: %v", input.Vers, err)
+			}
+			if got := ToVersString(r, r.Scheme); got != expected {
+				t.Errorf("round trip = %q, want %q", got, expected)
+			}
+		})
+	}
+}
+
 //nolint:gocognit
 func TestConformance_VersionComparison(t *testing.T) {
 	files := []string{
+		"alpine_version_cmp_test.json",
+		"alpm_version_cmp_test.json",
+		"conan_version_cmp_test.json",
+		"gentoo_version_cmp_test.json",
+		"lexicographic-test.json",
 		"nuget_version_cmp_test.json",
 		"maven_version_cmp_test.json",
+		"openssl_version_cmp_test.json",
 	}
 
 	for _, file := range files {

--- a/constraint.go
+++ b/constraint.go
@@ -16,11 +16,17 @@ var operatorRegex = regexp.MustCompile(`^(!=|>=|<=|[<>=])`)
 type Constraint struct {
 	Operator string
 	Version  string
+	Scheme   string
 }
 
 // ParseConstraint parses a constraint string into a Constraint.
 func ParseConstraint(s string) (*Constraint, error) {
 	return parseConstraintWithScheme(s, "")
+}
+
+// ParseConstraintWithScheme parses a constraint using scheme-specific comparison rules.
+func ParseConstraintWithScheme(s, scheme string) (*Constraint, error) {
+	return parseConstraintWithScheme(s, scheme)
 }
 
 // parseConstraintWithScheme parses a constraint with scheme-specific handling.
@@ -47,7 +53,7 @@ func parseConstraintWithScheme(s, scheme string) (*Constraint, error) {
 		if !preserveVPrefix {
 			version = stripVPrefix(version)
 		}
-		return &Constraint{Operator: operator, Version: version}, nil
+		return &Constraint{Operator: operator, Version: version, Scheme: scheme}, nil
 	}
 
 	// No operator found, treat as exact match
@@ -56,9 +62,9 @@ func parseConstraintWithScheme(s, scheme string) (*Constraint, error) {
 		version = decoded
 	}
 	if !preserveVPrefix {
-		version = stripVPrefix(s)
+		version = stripVPrefix(version)
 	}
-	return &Constraint{Operator: "=", Version: version}, nil
+	return &Constraint{Operator: "=", Version: version, Scheme: scheme}, nil
 }
 
 // stripVPrefix removes a leading 'v' or 'V' from version strings.
@@ -98,7 +104,16 @@ func (c *Constraint) IsExclusion() bool {
 
 // Satisfies checks if a version satisfies this constraint.
 func (c *Constraint) Satisfies(version string) bool {
-	cmp := CompareVersions(version, c.Version)
+	return c.satisfiesCmp(version, compareFuncFor(c.Scheme))
+}
+
+// SatisfiesWithScheme checks the constraint using the specified version scheme.
+func (c *Constraint) SatisfiesWithScheme(version, scheme string) bool {
+	return c.satisfiesCmp(version, compareFuncFor(scheme))
+}
+
+func (c *Constraint) satisfiesCmp(version string, compare func(a, b string) int) bool {
+	cmp := compare(version, c.Version)
 
 	switch c.Operator {
 	case "=":

--- a/constraint.go
+++ b/constraint.go
@@ -38,7 +38,7 @@ func parseConstraintWithScheme(s, scheme string) (*Constraint, error) {
 	}
 
 	// Go versions preserve the v prefix
-	preserveVPrefix := scheme == "go" || scheme == "golang"
+	preserveVPrefix := scheme == schemeGo || scheme == schemeGolang
 
 	matches := operatorRegex.FindStringSubmatch(s)
 	if matches != nil {

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -16,6 +16,7 @@ func TestParseConstraint(t *testing.T) {
 		{"=1.0.0", "=", "1.0.0", false},
 		{"!=1.5.0", "!=", "1.5.0", false},
 		{"1.0.0", "=", "1.0.0", false}, // No operator defaults to =
+		{"1.0%2Bmeta", "=", "1.0+meta", false},
 		{"", "", "", true},
 		{">=", "", "", true}, // Missing version
 	}

--- a/ecosystem_extra.go
+++ b/ecosystem_extra.go
@@ -218,7 +218,7 @@ func compareGentooBase(a, b string) int {
 			continue
 		}
 		var c int
-		if !strings.HasPrefix(pa[i], "0") && !strings.HasPrefix(pb[i], "0") {
+		if i == 0 || (!strings.HasPrefix(pa[i], "0") && !strings.HasPrefix(pb[i], "0")) {
 			c = cmpNumStr(pa[i], pb[i])
 		} else {
 			c = cmpString(strings.TrimRight(pa[i], "0"), strings.TrimRight(pb[i], "0"))
@@ -282,9 +282,9 @@ func parseGentooSuffix(s string) (kind, number string) {
 
 func gentooSuffixRank(s string) int {
 	switch s {
-	case "alpha":
+	case qualifierAlpha:
 		return -4
-	case "beta":
+	case qualifierBeta:
 		return -3
 	case "pre":
 		return -2

--- a/ecosystem_extra.go
+++ b/ecosystem_extra.go
@@ -1,0 +1,298 @@
+package vers
+
+import "strings"
+
+const (
+	segmentDigit = iota
+	segmentAlpha
+	segmentOther
+)
+
+type typedSegment struct {
+	value string
+	kind  int
+}
+
+func compareALPM(a, b string) int {
+	ea, va, ra, hasRA := splitALPMVersion(a)
+	eb, vb, rb, hasRB := splitALPMVersion(b)
+	if c := compareALPMPart(ea, eb); c != 0 {
+		return c
+	}
+	if c := compareALPMPart(va, vb); c != 0 {
+		return c
+	}
+	if hasRA && hasRB {
+		return compareALPMPart(ra, rb)
+	}
+	return 0
+}
+
+func splitALPMVersion(s string) (epoch, version, release string, hasRelease bool) {
+	epoch, version = "0", s
+	if i := strings.IndexByte(version, ':'); i >= 0 {
+		epoch, version = version[:i], version[i+1:]
+	}
+	if i := strings.LastIndexByte(version, '-'); i >= 0 {
+		version, release, hasRelease = version[:i], version[i+1:], true
+	}
+	return epoch, version, release, hasRelease
+}
+
+func splitTypedSegments(s string) []typedSegment {
+	if s == "" {
+		return nil
+	}
+	segments := make([]typedSegment, 0)
+	start, kind := 0, segmentKind(s[0])
+	for i := 1; i < len(s); i++ {
+		if next := segmentKind(s[i]); next != kind {
+			segments = append(segments, typedSegment{value: s[start:i], kind: kind})
+			start, kind = i, next
+		}
+	}
+	return append(segments, typedSegment{value: s[start:], kind: kind})
+}
+
+func segmentKind(c byte) int {
+	if isASCIIDigit(c) {
+		return segmentDigit
+	}
+	if isASCIIAlpha(c) {
+		return segmentAlpha
+	}
+	return segmentOther
+}
+
+func compareALPMPart(a, b string) int {
+	pa, pb := splitTypedSegments(a), splitTypedSegments(b)
+	for i := 0; i < len(pa) || i < len(pb); i++ {
+		if i >= len(pa) {
+			if pb[i].kind == segmentAlpha {
+				return 1
+			}
+			return -1
+		}
+		if i >= len(pb) {
+			if pa[i].kind == segmentAlpha {
+				return -1
+			}
+			return 1
+		}
+		a, b := pa[i], pb[i]
+		if a.kind != b.kind {
+			if a.kind == segmentDigit {
+				return 1
+			}
+			if b.kind == segmentDigit {
+				return -1
+			}
+			if a.kind == segmentOther {
+				return 1
+			}
+			return -1
+		}
+		var c int
+		switch a.kind {
+		case segmentDigit:
+			c = cmpNumStr(a.value, b.value)
+		case segmentAlpha:
+			c = cmpString(a.value, b.value)
+		default:
+			c = cmpInt(len(a.value), len(b.value))
+		}
+		if c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+type conanVersion struct {
+	main  []conanItem
+	pre   *conanVersion
+	build *conanVersion
+}
+
+type conanItem struct {
+	value string
+	num   bool
+}
+
+func compareConan(a, b string) int {
+	return compareConanVersion(parseConanVersion(a), parseConanVersion(b))
+}
+
+func parseConanVersion(s string) conanVersion {
+	v := conanVersion{}
+	if i := strings.LastIndexByte(s, '+'); i >= 0 {
+		build := parseConanVersion(s[i+1:])
+		v.build, s = &build, s[:i]
+	}
+	if i := strings.LastIndexByte(s, '-'); i >= 0 {
+		pre := parseConanVersion(s[i+1:])
+		v.pre, s = &pre, s[:i]
+	}
+	for _, item := range strings.Split(s, ".") {
+		v.main = append(v.main, conanItem{value: item, num: isDigits(item)})
+	}
+	for len(v.main) > 0 && v.main[len(v.main)-1].num && cmpNumStr(v.main[len(v.main)-1].value, "0") == 0 {
+		v.main = v.main[:len(v.main)-1]
+	}
+	return v
+}
+
+func compareConanVersion(a, b conanVersion) int {
+	if c := compareConanItems(a.main, b.main); c != 0 {
+		return c
+	}
+	if c := compareOptionalConan(a.pre, b.pre, true); c != 0 {
+		return c
+	}
+	return compareOptionalConan(a.build, b.build, false)
+}
+
+func compareConanItems(a, b []conanItem) int {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		var c int
+		if a[i].num && b[i].num {
+			c = cmpNumStr(a[i].value, b[i].value)
+		} else {
+			c = cmpString(a[i].value, b[i].value)
+		}
+		if c != 0 {
+			return c
+		}
+	}
+	return cmpInt(len(a), len(b))
+}
+
+func compareOptionalConan(a, b *conanVersion, prerelease bool) int {
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil {
+		if prerelease {
+			return 1
+		}
+		return -1
+	}
+	if b == nil {
+		if prerelease {
+			return -1
+		}
+		return 1
+	}
+	return compareConanVersion(*a, *b)
+}
+
+func compareGentoo(a, b string) int {
+	va, ra := splitGentooRevision(a)
+	vb, rb := splitGentooRevision(b)
+	if va == vb {
+		return cmpNumStr(ra, rb)
+	}
+	pa, pb := strings.Split(va, "_"), strings.Split(vb, "_")
+	if c := compareGentooBase(pa[0], pb[0]); c != 0 {
+		return c
+	}
+	if c := compareGentooSuffixes(pa[1:], pb[1:]); c != 0 {
+		return c
+	}
+	return cmpNumStr(ra, rb)
+}
+
+func splitGentooRevision(s string) (version, revision string) {
+	version = s
+	if i := strings.LastIndex(s, "-r"); i >= 0 && isDigits(s[i+2:]) {
+		version, revision = s[:i], s[i+2:]
+	}
+	return version, revision
+}
+
+func compareGentooBase(a, b string) int {
+	pa, la := splitGentooBase(a)
+	pb, lb := splitGentooBase(b)
+	for i := 0; i < len(pa) && i < len(pb); i++ {
+		if pa[i] == pb[i] {
+			continue
+		}
+		var c int
+		if !strings.HasPrefix(pa[i], "0") && !strings.HasPrefix(pb[i], "0") {
+			c = cmpNumStr(pa[i], pb[i])
+		} else {
+			c = cmpString(strings.TrimRight(pa[i], "0"), strings.TrimRight(pb[i], "0"))
+		}
+		if c != 0 {
+			return c
+		}
+	}
+	if len(pa) != len(pb) {
+		return cmpInt(len(pa), len(pb))
+	}
+	return cmpInt(la, lb)
+}
+
+func splitGentooBase(s string) ([]string, int) {
+	parts := strings.Split(s, ".")
+	letter := -1
+	last := parts[len(parts)-1]
+	if len(last) > 0 && isASCIIAlpha(last[len(last)-1]) {
+		letter = int(last[len(last)-1])
+		parts[len(parts)-1] = last[:len(last)-1]
+	}
+	return parts, letter
+}
+
+func compareGentooSuffixes(a, b []string) int {
+	for i := 0; i < len(a) || i < len(b); i++ {
+		if i >= len(a) {
+			kind, number := parseGentooSuffix(b[i])
+			if rank := gentooSuffixRank(kind); rank != 0 {
+				return cmpInt(0, rank)
+			}
+			return cmpNumStr("0", number)
+		}
+		if i >= len(b) {
+			kind, number := parseGentooSuffix(a[i])
+			if rank := gentooSuffixRank(kind); rank != 0 {
+				return cmpInt(rank, 0)
+			}
+			return cmpNumStr(number, "0")
+		}
+		ka, na := parseGentooSuffix(a[i])
+		kb, nb := parseGentooSuffix(b[i])
+		if c := cmpInt(gentooSuffixRank(ka), gentooSuffixRank(kb)); c != 0 {
+			return c
+		}
+		if c := cmpNumStr(na, nb); c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+func parseGentooSuffix(s string) (kind, number string) {
+	i := len(s)
+	for i > 0 && isASCIIDigit(s[i-1]) {
+		i--
+	}
+	return s[:i], s[i:]
+}
+
+func gentooSuffixRank(s string) int {
+	switch s {
+	case "alpha":
+		return -4
+	case "beta":
+		return -3
+	case "pre":
+		return -2
+	case "rc":
+		return -1
+	case "p":
+		return 1
+	default:
+		return 0
+	}
+}

--- a/interval.go
+++ b/interval.go
@@ -51,6 +51,11 @@ func (i Interval) IsEmpty() bool {
 	return i.isEmptyCmp(CompareVersions)
 }
 
+// IsEmptyWithScheme reports whether the interval is empty under a version scheme.
+func (i Interval) IsEmptyWithScheme(scheme string) bool {
+	return i.isEmptyCmp(compareFuncFor(scheme))
+}
+
 func (i Interval) isEmptyCmp(cmp func(a, b string) int) bool {
 	if i.Min != "" && i.Max != "" {
 		c := cmp(i.Min, i.Max)
@@ -72,6 +77,11 @@ func (i Interval) IsUnbounded() bool {
 // Contains checks if the interval contains the given version.
 func (i Interval) Contains(version string) bool {
 	return i.containsCmp(version, CompareVersions)
+}
+
+// ContainsWithScheme checks containment under a version scheme.
+func (i Interval) ContainsWithScheme(version, scheme string) bool {
+	return i.containsCmp(version, compareFuncFor(scheme))
 }
 
 func (i Interval) containsCmp(version string, cmp func(a, b string) int) bool {
@@ -116,6 +126,11 @@ func (i Interval) containsCmp(version string, cmp func(a, b string) int) bool {
 // Intersect returns the intersection of two intervals.
 func (i Interval) Intersect(other Interval) Interval {
 	return i.intersectCmp(other, CompareVersions)
+}
+
+// IntersectWithScheme returns the intersection under a version scheme.
+func (i Interval) IntersectWithScheme(other Interval, scheme string) Interval {
+	return i.intersectCmp(other, compareFuncFor(scheme))
 }
 
 func (i Interval) intersectCmp(other Interval, cmp func(a, b string) int) Interval {
@@ -179,6 +194,11 @@ func (i Interval) Overlaps(other Interval) bool {
 	return i.overlapsCmp(other, CompareVersions)
 }
 
+// OverlapsWithScheme reports overlap under a version scheme.
+func (i Interval) OverlapsWithScheme(other Interval, scheme string) bool {
+	return i.overlapsCmp(other, compareFuncFor(scheme))
+}
+
 func (i Interval) overlapsCmp(other Interval, cmp func(a, b string) int) bool {
 	if i.isEmptyCmp(cmp) || other.isEmptyCmp(cmp) {
 		return false
@@ -189,6 +209,11 @@ func (i Interval) overlapsCmp(other Interval, cmp func(a, b string) int) bool {
 // Adjacent returns true if the two intervals are adjacent (can be merged).
 func (i Interval) Adjacent(other Interval) bool {
 	return i.adjacentCmp(other, CompareVersions)
+}
+
+// AdjacentWithScheme reports adjacency under a version scheme.
+func (i Interval) AdjacentWithScheme(other Interval, scheme string) bool {
+	return i.adjacentCmp(other, compareFuncFor(scheme))
 }
 
 func (i Interval) adjacentCmp(other Interval, cmp func(a, b string) int) bool {
@@ -210,6 +235,11 @@ func (i Interval) adjacentCmp(other Interval, cmp func(a, b string) int) bool {
 // Union returns the union of two intervals, or nil if they cannot be merged.
 func (i Interval) Union(other Interval) *Interval {
 	return i.unionCmp(other, CompareVersions)
+}
+
+// UnionWithScheme returns the union under a version scheme.
+func (i Interval) UnionWithScheme(other Interval, scheme string) *Interval {
+	return i.unionCmp(other, compareFuncFor(scheme))
 }
 
 func (i Interval) unionCmp(other Interval, cmp func(a, b string) int) *Interval {
@@ -269,7 +299,16 @@ func (i Interval) unionCmp(other Interval, cmp func(a, b string) int) *Interval 
 
 // String returns a string representation of the interval.
 func (i Interval) String() string {
-	if i.IsEmpty() {
+	return i.stringCmp(CompareVersions)
+}
+
+// StringWithScheme formats the interval under a version scheme.
+func (i Interval) StringWithScheme(scheme string) string {
+	return i.stringCmp(compareFuncFor(scheme))
+}
+
+func (i Interval) stringCmp(cmp func(a, b string) int) string {
+	if i.isEmptyCmp(cmp) {
 		return "empty"
 	}
 	if i.IsUnbounded() {

--- a/normalization.go
+++ b/normalization.go
@@ -19,25 +19,25 @@ func validVersionForScheme(version, scheme string) bool { //nolint:gocyclo
 	}
 
 	switch scheme {
-	case "pypi":
+	case schemePyPI:
 		_, ok := parsePEP440(version)
 		return ok
-	case "semver", "npm", "cargo", "go", "golang", "hex", "elixir":
+	case schemeSemVer, schemeNPM, schemeCargo, schemeGo, schemeGolang, schemeHex, schemeElixir:
 		return validSemverLike(version)
-	case "gem", "rubygems":
+	case schemeGem, schemeRubyGems:
 		return gemVersionRegex.MatchString(version)
-	case "deb", "debian":
+	case schemeDeb, schemeDebian:
 		return validDebianVersion(version)
-	case "rpm":
+	case schemeRPM:
 		return validRPMVersion(version)
-	case "nuget":
+	case schemeNuGet:
 		return nugetVersionRegex.MatchString(version)
-	case "intdot":
+	case schemeIntDot:
 		return intDotVersionRegex.MatchString(version)
-	case "openssl":
+	case schemeOpenSSL:
 		_, ok := parseOpenSSLVersion(version)
 		return ok
-	case "maven", "lexicographic", "datetime", "apk", "alpine", "gentoo", "alpm", "conan":
+	case schemeMaven, schemeLexicographic, schemeDatetime, schemeAPK, schemeAlpine, schemeGentoo, schemeALPM, schemeConan:
 		return !strings.ContainsAny(version, " \t\r\n")
 	default:
 		return Valid(version)
@@ -54,13 +54,13 @@ func normalizeVersionForScheme(version, scheme string) (string, error) {
 	}
 
 	switch scheme {
-	case "pypi":
+	case schemePyPI:
 		v, _ := parsePEP440(version)
 		return formatPEP440(v), nil
-	case "semver", "npm", "cargo", "go", "golang", "hex", "elixir":
-		return normalizeSemverLike(version, scheme == "go" || scheme == "golang"), nil
-	case "gem", "rubygems", "deb", "debian", "rpm", "nuget", "intdot", "openssl",
-		"maven", "lexicographic", "datetime", "apk", "alpine", "gentoo", "alpm", "conan":
+	case schemeSemVer, schemeNPM, schemeCargo, schemeGo, schemeGolang, schemeHex, schemeElixir:
+		return normalizeSemverLike(version, scheme == schemeGo || scheme == schemeGolang), nil
+	case schemeGem, schemeRubyGems, schemeDeb, schemeDebian, schemeRPM, schemeNuGet, schemeIntDot, schemeOpenSSL,
+		schemeMaven, schemeLexicographic, schemeDatetime, schemeAPK, schemeAlpine, schemeGentoo, schemeALPM, schemeConan:
 		return version, nil
 	default:
 		return Normalize(version)

--- a/normalization.go
+++ b/normalization.go
@@ -1,0 +1,194 @@
+package vers
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var (
+	gemVersionRegex    = regexp.MustCompile(`^[0-9]+(?:\.[0-9A-Za-z]+)*(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?$`)
+	nugetVersionRegex  = regexp.MustCompile(`^[0-9]+(?:\.[0-9]+){0,3}(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$`)
+	intDotVersionRegex = regexp.MustCompile(`^[0-9]+(?:\.[0-9]+)*$`)
+)
+
+func validVersionForScheme(version, scheme string) bool { //nolint:gocyclo
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return false
+	}
+
+	switch scheme {
+	case "pypi":
+		_, ok := parsePEP440(version)
+		return ok
+	case "semver", "npm", "cargo", "go", "golang", "hex", "elixir":
+		return validSemverLike(version)
+	case "gem", "rubygems":
+		return gemVersionRegex.MatchString(version)
+	case "deb", "debian":
+		return validDebianVersion(version)
+	case "rpm":
+		return validRPMVersion(version)
+	case "nuget":
+		return nugetVersionRegex.MatchString(version)
+	case "intdot":
+		return intDotVersionRegex.MatchString(version)
+	case "openssl":
+		_, ok := parseOpenSSLVersion(version)
+		return ok
+	case "maven", "lexicographic", "datetime", "apk", "alpine", "gentoo", "alpm", "conan":
+		return !strings.ContainsAny(version, " \t\r\n")
+	default:
+		return Valid(version)
+	}
+}
+
+func normalizeVersionForScheme(version, scheme string) (string, error) {
+	version = strings.TrimSpace(version)
+	if scheme == "" {
+		return Normalize(version)
+	}
+	if !validVersionForScheme(version, scheme) {
+		return "", fmt.Errorf("invalid %s version: %s", scheme, version)
+	}
+
+	switch scheme {
+	case "pypi":
+		v, _ := parsePEP440(version)
+		return formatPEP440(v), nil
+	case "semver", "npm", "cargo", "go", "golang", "hex", "elixir":
+		return normalizeSemverLike(version, scheme == "go" || scheme == "golang"), nil
+	case "gem", "rubygems", "deb", "debian", "rpm", "nuget", "intdot", "openssl",
+		"maven", "lexicographic", "datetime", "apk", "alpine", "gentoo", "alpm", "conan":
+		return version, nil
+	default:
+		return Normalize(version)
+	}
+}
+
+func validSemverLike(s string) bool {
+	m := SemanticVersionRegex.FindStringSubmatch(s)
+	if m == nil {
+		return false
+	}
+	for _, field := range []string{m[4], m[5]} {
+		if field == "" {
+			continue
+		}
+		for _, part := range strings.Split(field, ".") {
+			if part == "" || strings.Trim(part, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-") != "" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func normalizeSemverLike(s string, preserveV bool) string {
+	m := SemanticVersionRegex.FindStringSubmatch(s)
+	core := []string{trimLeadingZeros(m[1]), trimLeadingZeros(m[2]), trimLeadingZeros(m[3])}
+	result := strings.Join(core, ".")
+	if preserveV && (strings.HasPrefix(s, "v") || strings.HasPrefix(s, "V")) {
+		result = "v" + result
+	}
+	if m[4] != "" {
+		parts := strings.Split(m[4], ".")
+		for i, part := range parts {
+			if isDigits(part) {
+				parts[i] = trimLeadingZeros(part)
+			}
+		}
+		result += "-" + strings.Join(parts, ".")
+	}
+	if m[5] != "" {
+		result += "+" + m[5]
+	}
+	return result
+}
+
+func formatPEP440(v pep440Version) string {
+	var result strings.Builder
+	if cmpNumStr(v.epoch, "0") != 0 {
+		result.WriteString(trimLeadingZeros(v.epoch))
+		result.WriteByte('!')
+	}
+	for i, part := range v.release {
+		if i > 0 {
+			result.WriteByte('.')
+		}
+		result.WriteString(trimLeadingZeros(part))
+	}
+	if v.hasPre {
+		result.WriteString([]string{"a", "b", "rc"}[v.preTag])
+		result.WriteString(trimLeadingZeros(v.preNum))
+	}
+	if v.hasPost {
+		result.WriteString(".post")
+		result.WriteString(trimLeadingZeros(v.post))
+	}
+	if v.hasDev {
+		result.WriteString(".dev")
+		result.WriteString(trimLeadingZeros(v.dev))
+	}
+	if len(v.local) > 0 {
+		result.WriteByte('+')
+		for i, part := range v.local {
+			if i > 0 {
+				result.WriteByte('.')
+			}
+			if part.isNum {
+				result.WriteString(trimLeadingZeros(part.s))
+			} else {
+				result.WriteString(part.s)
+			}
+		}
+	}
+	return result.String()
+}
+
+func validDebianVersion(s string) bool {
+	epoch, upstream, revision := splitDebianVersion(s)
+	if epoch != "" && !isDigits(epoch) {
+		return false
+	}
+	if upstream == "" || !isASCIIDigit(upstream[0]) || !containsOnly(upstream, isDebianUpstreamChar) {
+		return false
+	}
+	return revision == "0" || (revision != "" && containsOnly(revision, isDebianRevisionChar))
+}
+
+func validRPMVersion(s string) bool {
+	if strings.HasSuffix(s, "-") {
+		return false
+	}
+	epoch, version, release := splitRPMVersion(s)
+	if epoch != "" && !isDigits(epoch) {
+		return false
+	}
+	if version == "" || !containsOnly(version, isRPMVersionChar) {
+		return false
+	}
+	return release == "" || containsOnly(release, isRPMVersionChar)
+}
+
+func containsOnly(s string, valid func(byte) bool) bool {
+	for i := 0; i < len(s); i++ {
+		if !valid(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isDebianUpstreamChar(c byte) bool {
+	return isASCIIAlnum(c) || strings.ContainsRune(".+-~", rune(c))
+}
+
+func isDebianRevisionChar(c byte) bool {
+	return isASCIIAlnum(c) || strings.ContainsRune(".+~", rune(c))
+}
+
+func isRPMVersionChar(c byte) bool {
+	return isASCIIAlnum(c) || strings.ContainsRune("._+~^", rune(c))
+}

--- a/parser.go
+++ b/parser.go
@@ -48,31 +48,31 @@ func (p *Parser) ParseNative(constraint string, scheme string) (*Range, error) {
 
 func (p *Parser) parseNative(constraint string, scheme string) (*Range, error) {
 	switch scheme {
-	case "npm":
+	case schemeNPM:
 		return p.parseNpmRange(constraint)
-	case "gem", "rubygems":
+	case schemeGem, schemeRubyGems:
 		return p.parseGemRange(constraint)
-	case "pypi": //nolint:goconst
+	case schemePyPI:
 		return p.parsePypiRange(constraint)
-	case "maven":
+	case schemeMaven:
 		return p.parseMavenRange(constraint)
-	case "nuget": //nolint:goconst
+	case schemeNuGet:
 		return p.parseNugetRange(constraint)
-	case "cargo":
+	case schemeCargo:
 		return p.parseCargoRange(constraint)
-	case "go", "golang":
+	case schemeGo, schemeGolang:
 		return p.parseGoRange(constraint)
-	case "hex", "elixir":
+	case schemeHex, schemeElixir:
 		return p.parseHexRange(constraint)
-	case "deb", "debian":
+	case schemeDeb, schemeDebian:
 		return p.parseDebianRange(constraint)
-	case "rpm":
+	case schemeRPM:
 		return p.parseRpmRange(constraint)
-	case "conan":
+	case schemeConan:
 		return p.parseConanRange(constraint)
-	case "openssl":
+	case schemeOpenSSL:
 		return p.parseOpenSSLRange(constraint)
-	case "nginx":
+	case schemeNginx:
 		return p.parseNginxRange(constraint)
 	default:
 		return p.parseConstraints(constraint, scheme)
@@ -193,7 +193,7 @@ func normalizeVersion(version, scheme string) string {
 	dots := strings.Count(version, ".")
 
 	switch scheme {
-	case "npm", "cargo", "nuget":
+	case schemeNPM, schemeCargo, schemeNuGet:
 		// These schemes use semver, normalize to 3 parts
 		switch dots {
 		case 0:
@@ -562,11 +562,11 @@ func (p *Parser) parseGemRange(s string) (*Range, error) {
 	}
 
 	// Standard constraint
-	return p.parseConstraints(s, "gem")
+	return p.parseConstraints(s, schemeGem)
 }
 
 func (p *Parser) parseGemPessimisticRange(version string) (*Range, error) {
-	if !validVersionForScheme(version, "gem") {
+	if !validVersionForScheme(version, schemeGem) {
 		return nil, fmt.Errorf("invalid gem version: %s", version)
 	}
 	segments := parseGemRawSegments(version)
@@ -584,13 +584,13 @@ func (p *Parser) parseGemPessimisticRange(version string) (*Range, error) {
 	if len(release) == 1 {
 		upper = incNumStr(release[0])
 	} else {
-		head := release[:len(release)-1]
+		head := append([]string(nil), release[:len(release)-1]...)
 		head[len(head)-1] = incNumStr(head[len(head)-1])
 		upper = strings.Join(head, ".")
 	}
 	return &Range{
 		Intervals: []Interval{NewInterval(version, upper, true, false)},
-		Scheme:    "gem",
+		Scheme:    schemeGem,
 	}, nil
 }
 
@@ -646,7 +646,7 @@ func (p *Parser) parsePypiRange(s string) (*Range, error) {
 		return p.parsePypiCompatibleRelease(version)
 	}
 
-	return p.parseConstraints(s, "pypi")
+	return p.parseConstraints(s, schemePyPI)
 }
 
 // parsePypiCompatibleRelease handles PEP 440 ~= by deriving the upper bound
@@ -666,7 +666,7 @@ func (p *Parser) parsePypiCompatibleRelease(version string) (*Range, error) {
 			return nil, err
 		}
 	}
-	r.Scheme = "pypi" //nolint:goconst
+	r.Scheme = schemePyPI
 	return r, nil
 }
 
@@ -687,7 +687,7 @@ func (p *Parser) parseMavenRange(s string) (*Range, error) {
 		}), nil
 	}
 
-	return p.parseConstraints(s, "maven")
+	return p.parseConstraints(s, schemeMaven)
 }
 
 func (p *Parser) parseBracketRange(s string) (*Range, error) {
@@ -758,7 +758,7 @@ func (p *Parser) parseGoRange(s string) (*Range, error) {
 		parts := strings.Split(s, ",")
 		var result *Range
 		for _, part := range parts {
-			constraint, err := parseConstraintWithScheme(strings.TrimSpace(part), "go")
+			constraint, err := parseConstraintWithScheme(strings.TrimSpace(part), schemeGo)
 			if err != nil {
 				return nil, err
 			}
@@ -776,7 +776,7 @@ func (p *Parser) parseGoRange(s string) (*Range, error) {
 		return result, nil
 	}
 
-	return p.parseConstraints(s, "go")
+	return p.parseConstraints(s, schemeGo)
 }
 
 // hex/elixir: ~> 1.2.3, >= 1.0.0 and < 2.0.0, ~> 1.0 or ~> 2.0
@@ -861,12 +861,12 @@ func (p *Parser) parseDebianRange(s string) (*Range, error) {
 	// Convert Debian operators to standard
 	s = strings.ReplaceAll(s, ">>", ">")
 	s = strings.ReplaceAll(s, "<<", "<")
-	return p.parseConstraints(s, "deb")
+	return p.parseConstraints(s, schemeDeb)
 }
 
 // rpm: >= 1.0, <= 2.0
 func (p *Parser) parseRpmRange(s string) (*Range, error) {
-	return p.parseConstraints(s, "rpm")
+	return p.parseConstraints(s, schemeRPM)
 }
 
 // conan: >1 <2, ~1.2, ^1.2.3, ||
@@ -919,7 +919,7 @@ func (p *Parser) parseConanRange(s string) (*Range, error) {
 		}
 		return NewRange([]Interval{NewInterval(version, upper, true, false)}), nil
 	}
-	return p.parseConstraints(s, "conan")
+	return p.parseConstraints(s, schemeConan)
 }
 
 func conanUpperBound(version string, operator byte) (string, error) {
@@ -945,7 +945,7 @@ func conanUpperBound(version string, operator byte) (string, error) {
 
 // openssl native ranges are comma-separated exact releases.
 func (p *Parser) parseOpenSSLRange(s string) (*Range, error) {
-	return p.parseExactList(s, "openssl")
+	return p.parseExactList(s, schemeOpenSSL)
 }
 
 func (p *Parser) parseExactList(s, scheme string) (*Range, error) {
@@ -999,5 +999,5 @@ func (p *Parser) parseNginxRange(s string) (*Range, error) {
 		parts := strings.SplitN(s, "-", 2) //nolint:mnd
 		return NewRange([]Interval{NewInterval(parts[0], parts[1], true, true)}), nil
 	}
-	return p.parseConstraints(s, "nginx")
+	return p.parseConstraints(s, schemeNginx)
 }

--- a/parser.go
+++ b/parser.go
@@ -7,6 +7,7 @@ import (
 )
 
 var versURIRegex = regexp.MustCompile(`^vers:([^/]+)/(.*)$`)
+var nginxRangeRegex = regexp.MustCompile(`^\d+(?:\.\d+)+-\d+(?:\.\d+)+$`)
 
 // Parser handles parsing of vers URIs and native package manager syntax.
 type Parser struct{}
@@ -39,7 +40,7 @@ func (p *Parser) Parse(versURI string) (*Range, error) {
 // ParseNative parses a native package manager version range into a Range.
 func (p *Parser) ParseNative(constraint string, scheme string) (*Range, error) {
 	r, err := p.parseNative(constraint, scheme)
-	if r != nil && r.Scheme == "" {
+	if r != nil {
 		r.Scheme = scheme
 	}
 	return r, err
@@ -67,6 +68,12 @@ func (p *Parser) parseNative(constraint string, scheme string) (*Range, error) {
 		return p.parseDebianRange(constraint)
 	case "rpm":
 		return p.parseRpmRange(constraint)
+	case "conan":
+		return p.parseConanRange(constraint)
+	case "openssl":
+		return p.parseOpenSSLRange(constraint)
+	case "nginx":
+		return p.parseNginxRange(constraint)
 	default:
 		return p.parseConstraints(constraint, scheme)
 	}
@@ -129,7 +136,7 @@ func (p *Parser) ToVersString(r *Range, scheme string) string {
 	}
 
 	// Sort constraints by version
-	sortConstraintsByVersion(constraints)
+	sortConstraintsByVersion(constraints, scheme)
 
 	var strs []string
 	for _, c := range constraints {
@@ -146,11 +153,13 @@ type constraintWithVersion struct {
 }
 
 // sortConstraintsByVersion sorts constraints by their version in ascending order.
-func sortConstraintsByVersion(constraints []constraintWithVersion) {
+func sortConstraintsByVersion(constraints []constraintWithVersion, scheme string) {
+	cmp := compareFuncFor(scheme)
 	// Simple bubble sort to avoid import
 	for i := 0; i < len(constraints); i++ {
 		for j := i + 1; j < len(constraints); j++ {
-			if CompareVersions(constraints[i].sortKey, constraints[j].sortKey) > 0 {
+			order := cmp(constraints[i].sortKey, constraints[j].sortKey)
+			if order > 0 || (order == 0 && constraints[i].str > constraints[j].str) {
 				constraints[i], constraints[j] = constraints[j], constraints[i]
 			}
 		}
@@ -528,12 +537,6 @@ func (p *Parser) parseXRange(s string) (*Range, error) {
 func (p *Parser) parseGemRange(s string) (*Range, error) {
 	s = strings.TrimSpace(s)
 
-	// Pessimistic operator: ~> 1.2.3
-	if strings.HasPrefix(s, "~>") {
-		version := strings.TrimSpace(s[2:])
-		return p.parsePessimisticRange(version)
-	}
-
 	// Comma-separated constraints
 	if strings.Contains(s, ",") {
 		parts := strings.Split(s, ",")
@@ -552,8 +555,43 @@ func (p *Parser) parseGemRange(s string) (*Range, error) {
 		return result, nil
 	}
 
+	// Pessimistic operator: ~> 1.2.3
+	if strings.HasPrefix(s, "~>") {
+		version := strings.TrimSpace(s[2:])
+		return p.parseGemPessimisticRange(version)
+	}
+
 	// Standard constraint
 	return p.parseConstraints(s, "gem")
+}
+
+func (p *Parser) parseGemPessimisticRange(version string) (*Range, error) {
+	if !validVersionForScheme(version, "gem") {
+		return nil, fmt.Errorf("invalid gem version: %s", version)
+	}
+	segments := parseGemRawSegments(version)
+	var release []string
+	for _, segment := range segments {
+		if !segment.num {
+			break
+		}
+		release = append(release, segment.value)
+	}
+	if len(release) == 0 {
+		return nil, fmt.Errorf("invalid gem version: %s", version)
+	}
+	var upper string
+	if len(release) == 1 {
+		upper = incNumStr(release[0])
+	} else {
+		head := release[:len(release)-1]
+		head[len(head)-1] = incNumStr(head[len(head)-1])
+		upper = strings.Join(head, ".")
+	}
+	return &Range{
+		Intervals: []Interval{NewInterval(version, upper, true, false)},
+		Scheme:    "gem",
+	}, nil
 }
 
 // ~> 1.2.3 := >= 1.2.3, < 1.3
@@ -691,7 +729,25 @@ func (p *Parser) parseNugetRange(s string) (*Range, error) {
 
 // cargo: ^1.2.3, ~1.2.3, >=1.0.0
 func (p *Parser) parseCargoRange(s string) (*Range, error) {
-	// Cargo uses similar syntax to npm
+	s = strings.TrimSpace(s)
+	if strings.Contains(s, ",") {
+		var result *Range
+		for _, part := range strings.Split(s, ",") {
+			r, err := p.parseCargoRange(part)
+			if err != nil {
+				return nil, err
+			}
+			if result == nil {
+				result = r
+			} else {
+				result = result.Intersect(r)
+			}
+		}
+		return result, nil
+	}
+	if s != "" && !strings.ContainsAny(s, "^~*<>=") {
+		return p.parseCaretRange(s)
+	}
 	return p.parseNpmRange(s)
 }
 
@@ -811,4 +867,137 @@ func (p *Parser) parseDebianRange(s string) (*Range, error) {
 // rpm: >= 1.0, <= 2.0
 func (p *Parser) parseRpmRange(s string) (*Range, error) {
 	return p.parseConstraints(s, "rpm")
+}
+
+// conan: >1 <2, ~1.2, ^1.2.3, ||
+func (p *Parser) parseConanRange(s string) (*Range, error) {
+	s = strings.TrimSpace(s)
+	if i := strings.Index(s, ","); i >= 0 {
+		s = strings.TrimSpace(s[:i])
+	}
+	if s == "*" || s == "*-" {
+		return NewRange([]Interval{GreaterThanInterval("0.0.0", true)}), nil
+	}
+	if strings.Contains(s, "||") {
+		var intervals, raw []Interval
+		for _, part := range strings.Split(s, "||") {
+			r, err := p.parseConanRange(part)
+			if err != nil {
+				return nil, err
+			}
+			intervals = append(intervals, r.Intervals...)
+			if len(r.RawConstraints) > 0 {
+				raw = append(raw, r.RawConstraints...)
+			} else {
+				raw = append(raw, r.Intervals...)
+			}
+		}
+		return &Range{Intervals: mergeIntervals(intervals, compareConan), RawConstraints: raw}, nil
+	}
+	if strings.Contains(s, " ") {
+		var result *Range
+		for _, part := range tokenizeNpmConstraints(s) {
+			r, err := p.parseConanRange(part)
+			if err != nil {
+				return nil, err
+			}
+			if result == nil {
+				result = r
+			} else {
+				result = result.Intersect(r)
+			}
+		}
+		return result, nil
+	}
+
+	s = strings.TrimSuffix(s, "-")
+	if strings.HasPrefix(s, "~") || strings.HasPrefix(s, "^") {
+		operator, version := s[0], strings.TrimSpace(s[1:])
+		upper, err := conanUpperBound(version, operator)
+		if err != nil {
+			return nil, err
+		}
+		return NewRange([]Interval{NewInterval(version, upper, true, false)}), nil
+	}
+	return p.parseConstraints(s, "conan")
+}
+
+func conanUpperBound(version string, operator byte) (string, error) {
+	parts := strings.Split(version, ".")
+	for _, part := range parts {
+		if !isDigits(part) {
+			return "", fmt.Errorf("invalid conan version range: %c%s", operator, version)
+		}
+	}
+
+	index := 0
+	if operator == '~' && len(parts) > 1 {
+		index = 1
+	} else if operator == '^' {
+		for index < len(parts)-1 && cmpNumStr(parts[index], "0") == 0 {
+			index++
+		}
+	}
+	upper := append([]string(nil), parts[:index+1]...)
+	upper[index] = incNumStr(upper[index])
+	return strings.Join(upper, ".") + "-", nil
+}
+
+// openssl native ranges are comma-separated exact releases.
+func (p *Parser) parseOpenSSLRange(s string) (*Range, error) {
+	return p.parseExactList(s, "openssl")
+}
+
+func (p *Parser) parseExactList(s, scheme string) (*Range, error) {
+	parts := strings.Split(s, ",")
+	intervals := make([]Interval, 0, len(parts))
+	for _, part := range parts {
+		version := strings.TrimSpace(part)
+		if version == "" {
+			return nil, fmt.Errorf("empty %s version", scheme)
+		}
+		if !validVersionForScheme(version, scheme) {
+			return nil, fmt.Errorf("invalid %s version: %s", scheme, version)
+		}
+		intervals = append(intervals, ExactInterval(version))
+	}
+	return NewRange(intervals), nil
+}
+
+// nginx: 0.8.40+, 0.7.52-0.8.39, comma-separated unions.
+func (p *Parser) parseNginxRange(s string) (*Range, error) {
+	s = strings.TrimSpace(s)
+	if strings.Contains(s, ",") {
+		var intervals, raw []Interval
+		for _, part := range strings.Split(s, ",") {
+			r, err := p.parseNginxRange(part)
+			if err != nil {
+				return nil, err
+			}
+			intervals = append(intervals, r.Intervals...)
+			raw = append(raw, r.Intervals...)
+		}
+		return &Range{Intervals: mergeIntervals(intervals, compareSemver), RawConstraints: raw}, nil
+	}
+	if strings.HasSuffix(s, "+") {
+		version := strings.TrimSuffix(s, "+")
+		if !validSemverLike(version) {
+			return nil, fmt.Errorf("invalid nginx version range: %s", s)
+		}
+		parts := strings.Split(version, ".")
+		if len(parts) < 2 || !isDigits(parts[1]) {
+			return nil, fmt.Errorf("invalid nginx version range: %s", s)
+		}
+		interval := GreaterThanInterval(version, true)
+		minor := trimLeadingZeros(parts[1])
+		if minor[len(minor)-1]%2 == 0 {
+			interval.Max = strings.Join([]string{parts[0], incNumStr(parts[1]), "0"}, ".")
+		}
+		return NewRange([]Interval{interval}), nil
+	}
+	if nginxRangeRegex.MatchString(s) {
+		parts := strings.SplitN(s, "-", 2) //nolint:mnd
+		return NewRange([]Interval{NewInterval(parts[0], parts[1], true, true)}), nil
+	}
+	return p.parseConstraints(s, "nginx")
 }

--- a/pypi.go
+++ b/pypi.go
@@ -24,8 +24,8 @@ var pep440Regex = regexp.MustCompile(`(?i)^\s*v?` +
 
 //nolint:goconst,mnd
 var pep440PreTags = map[string]int{
-	"a": 0, "alpha": 0,
-	"b": 1, "beta": 1,
+	"a": 0, qualifierAlpha: 0,
+	"b": 1, qualifierBeta: 1,
 	"c": 2, "rc": 2, "pre": 2, "preview": 2,
 }
 

--- a/range.go
+++ b/range.go
@@ -1,6 +1,7 @@
 package vers
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 )
@@ -116,6 +117,15 @@ func (r *Range) Union(other *Range) *Range {
 	return &Range{Intervals: merged, Exclusions: exclusions, RawConstraints: rawConstraints, Scheme: r.Scheme}
 }
 
+// UnionChecked returns the union of ranges that use compatible schemes.
+func (r *Range) UnionChecked(other *Range) (*Range, error) {
+	if err := checkRangeSchemes(r, other); err != nil {
+		return nil, err
+	}
+	left, right := rangesWithCommonScheme(r, other)
+	return left.Union(right), nil
+}
+
 // Intersect returns a new Range that is the intersection of this range and another.
 func (r *Range) Intersect(other *Range) *Range {
 	// Combine raw constraints for VERS output (preserved even if result is empty)
@@ -170,6 +180,36 @@ func (r *Range) Intersect(other *Range) *Range {
 	return &Range{Intervals: merged, Exclusions: exclusions, RawConstraints: rawConstraints, Scheme: r.Scheme}
 }
 
+// IntersectChecked returns the intersection of ranges that use compatible schemes.
+func (r *Range) IntersectChecked(other *Range) (*Range, error) {
+	if err := checkRangeSchemes(r, other); err != nil {
+		return nil, err
+	}
+	left, right := rangesWithCommonScheme(r, other)
+	return left.Intersect(right), nil
+}
+
+func checkRangeSchemes(a, b *Range) error {
+	if a == nil || b == nil {
+		return fmt.Errorf("cannot combine a nil range")
+	}
+	sa, sb := canonicalScheme(a.Scheme), canonicalScheme(b.Scheme)
+	if sa != "" && sb != "" && sa != sb {
+		return fmt.Errorf("cannot combine %q and %q version schemes", a.Scheme, b.Scheme)
+	}
+	return nil
+}
+
+func rangesWithCommonScheme(a, b *Range) (*Range, *Range) {
+	scheme := a.Scheme
+	if scheme == "" {
+		scheme = b.Scheme
+	}
+	left, right := *a, *b
+	left.Scheme, right.Scheme = scheme, scheme
+	return &left, &right
+}
+
 // Exclude returns a new Range that excludes the given version.
 func (r *Range) Exclude(version string) *Range {
 	exclusions := make([]string, len(r.Exclusions), len(r.Exclusions)+1)
@@ -193,8 +233,9 @@ func (r *Range) String() string {
 	}
 
 	var parts []string
+	cmp := compareFuncFor(r.Scheme)
 	for _, interval := range r.Intervals {
-		parts = append(parts, interval.String())
+		parts = append(parts, interval.stringCmp(cmp))
 	}
 
 	result := strings.Join(parts, " | ")

--- a/schemes.go
+++ b/schemes.go
@@ -232,7 +232,7 @@ func debianCharOrder(c byte) int {
 	case isASCIIAlpha(c):
 		return int(c)
 	default:
-		return int(c) + 256
+		return int(c) + 256 //nolint:mnd // Debian orders non-letters above the ASCII letter range.
 	}
 }
 

--- a/schemes.go
+++ b/schemes.go
@@ -177,7 +177,7 @@ func splitDebianVersion(s string) (epoch, upstream, revision string) {
 	return epoch, upstream, revision
 }
 
-func compareDebianPart(a, b string) int {
+func compareDebianPart(a, b string) int { //nolint:gocognit
 	for ia, ib := 0, 0; ia < len(a) || ib < len(b); {
 		for (ia < len(a) && !isASCIIDigit(a[ia])) || (ib < len(b) && !isASCIIDigit(b[ib])) {
 			var ca, cb byte
@@ -259,7 +259,7 @@ func splitRPMVersion(s string) (epoch, version, release string) {
 	return epoch, version, release
 }
 
-func compareRPMPart(a, b string) int { //nolint:gocyclo
+func compareRPMPart(a, b string) int { //nolint:gocyclo,gocognit
 	ia, ib := 0, 0
 	for ia < len(a) || ib < len(b) {
 		for ia < len(a) && !isASCIIAlnum(a[ia]) && a[ia] != '~' && a[ia] != '^' {

--- a/schemes.go
+++ b/schemes.go
@@ -1,0 +1,406 @@
+package vers
+
+import (
+	"regexp"
+	"strings"
+)
+
+type semverValue struct {
+	core []string
+	pre  []string
+}
+
+func compareSemver(a, b string) int {
+	va, okA := parseSemverValue(a)
+	vb, okB := parseSemverValue(b)
+	if !okA || !okB {
+		return CompareVersions(a, b)
+	}
+	for i := range va.core {
+		if c := cmpNumStr(va.core[i], vb.core[i]); c != 0 {
+			return c
+		}
+	}
+	return compareSemverPrerelease(va.pre, vb.pre)
+}
+
+func parseSemverValue(s string) (semverValue, bool) {
+	m := SemanticVersionRegex.FindStringSubmatch(s)
+	if m == nil {
+		return semverValue{}, false
+	}
+	v := semverValue{core: []string{m[1], m[2], m[3]}}
+	if m[4] != "" {
+		v.pre = strings.Split(m[4], ".")
+	}
+	return v, true
+}
+
+func compareSemverPrerelease(a, b []string) int {
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+	if len(a) == 0 {
+		return 1
+	}
+	if len(b) == 0 {
+		return -1
+	}
+	for i := 0; i < len(a) && i < len(b); i++ {
+		aNum, bNum := isDigits(a[i]), isDigits(b[i])
+		if aNum != bNum {
+			if aNum {
+				return -1
+			}
+			return 1
+		}
+		var c int
+		if aNum {
+			c = cmpNumStr(a[i], b[i])
+		} else {
+			c = cmpString(a[i], b[i])
+		}
+		if c != 0 {
+			return c
+		}
+	}
+	return cmpInt(len(a), len(b))
+}
+
+type gemSegment struct {
+	value string
+	num   bool
+}
+
+var gemSegmentRegex = regexp.MustCompile(`[0-9]+|[A-Za-z]+`)
+
+func compareGem(a, b string) int {
+	return compareGemSegments(parseGemSegments(a), parseGemSegments(b))
+}
+
+func parseGemRawSegments(s string) []gemSegment {
+	s = strings.ReplaceAll(strings.TrimSpace(s), "-", ".pre.")
+	raw := gemSegmentRegex.FindAllString(s, -1)
+	parts := make([]gemSegment, 0, len(raw))
+	for _, part := range raw {
+		parts = append(parts, gemSegment{value: part, num: isDigits(part)})
+	}
+	return parts
+}
+
+func parseGemSegments(s string) []gemSegment {
+	parts := parseGemRawSegments(s)
+
+	firstAlpha := -1
+	for i, part := range parts {
+		if !part.num {
+			firstAlpha = i
+			break
+		}
+	}
+	if firstAlpha > 0 {
+		start := firstAlpha
+		for start > 0 && parts[start-1].num && cmpNumStr(parts[start-1].value, "0") == 0 {
+			start--
+		}
+		if start < firstAlpha {
+			parts = append(parts[:start], parts[firstAlpha:]...)
+		}
+	}
+	for len(parts) > 0 && parts[len(parts)-1].num && cmpNumStr(parts[len(parts)-1].value, "0") == 0 {
+		parts = parts[:len(parts)-1]
+	}
+	return parts
+}
+
+func compareGemSegments(a, b []gemSegment) int {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if a[i].num != b[i].num {
+			if a[i].num {
+				return 1
+			}
+			return -1
+		}
+		var c int
+		if a[i].num {
+			c = cmpNumStr(a[i].value, b[i].value)
+		} else {
+			c = cmpString(a[i].value, b[i].value)
+		}
+		if c != 0 {
+			return c
+		}
+	}
+	if len(a) == len(b) {
+		return 0
+	}
+	if len(a) < len(b) {
+		return compareMissingGemSegments(b[len(a):])
+	}
+	return -compareMissingGemSegments(a[len(b):])
+}
+
+func compareMissingGemSegments(remaining []gemSegment) int {
+	for _, part := range remaining {
+		if !part.num {
+			return 1
+		}
+		if cmpNumStr(part.value, "0") != 0 {
+			return -1
+		}
+	}
+	return 0
+}
+
+func compareDebian(a, b string) int {
+	ea, ua, ra := splitDebianVersion(a)
+	eb, ub, rb := splitDebianVersion(b)
+	if c := cmpNumStr(ea, eb); c != 0 {
+		return c
+	}
+	if c := compareDebianPart(ua, ub); c != 0 {
+		return c
+	}
+	return compareDebianPart(ra, rb)
+}
+
+func splitDebianVersion(s string) (epoch, upstream, revision string) {
+	upstream = s
+	if i := strings.IndexByte(upstream, ':'); i >= 0 {
+		epoch, upstream = upstream[:i], upstream[i+1:]
+	}
+	if i := strings.LastIndexByte(upstream, '-'); i >= 0 {
+		upstream, revision = upstream[:i], upstream[i+1:]
+	} else {
+		revision = "0"
+	}
+	return epoch, upstream, revision
+}
+
+func compareDebianPart(a, b string) int {
+	for ia, ib := 0, 0; ia < len(a) || ib < len(b); {
+		for (ia < len(a) && !isASCIIDigit(a[ia])) || (ib < len(b) && !isASCIIDigit(b[ib])) {
+			var ca, cb byte
+			if ia < len(a) && !isASCIIDigit(a[ia]) {
+				ca = a[ia]
+			}
+			if ib < len(b) && !isASCIIDigit(b[ib]) {
+				cb = b[ib]
+			}
+			if oa, ob := debianCharOrder(ca), debianCharOrder(cb); oa != ob {
+				return cmpInt(oa, ob)
+			}
+			if ca != 0 {
+				ia++
+			}
+			if cb != 0 {
+				ib++
+			}
+		}
+
+		za, zb := ia, ib
+		for za < len(a) && a[za] == '0' {
+			za++
+		}
+		for zb < len(b) && b[zb] == '0' {
+			zb++
+		}
+		ea, eb := za, zb
+		for ea < len(a) && isASCIIDigit(a[ea]) {
+			ea++
+		}
+		for eb < len(b) && isASCIIDigit(b[eb]) {
+			eb++
+		}
+		if ea-za != eb-zb {
+			return cmpInt(ea-za, eb-zb)
+		}
+		if c := cmpString(a[za:ea], b[zb:eb]); c != 0 {
+			return c
+		}
+		ia, ib = ea, eb
+	}
+	return 0
+}
+
+func debianCharOrder(c byte) int {
+	switch {
+	case c == '~':
+		return -1
+	case c == 0:
+		return 0
+	case isASCIIAlpha(c):
+		return int(c)
+	default:
+		return int(c) + 256
+	}
+}
+
+func compareRPM(a, b string) int {
+	ea, va, ra := splitRPMVersion(a)
+	eb, vb, rb := splitRPMVersion(b)
+	if c := cmpNumStr(ea, eb); c != 0 {
+		return c
+	}
+	if c := compareRPMPart(va, vb); c != 0 {
+		return c
+	}
+	return compareRPMPart(ra, rb)
+}
+
+func splitRPMVersion(s string) (epoch, version, release string) {
+	version = s
+	if i := strings.IndexByte(version, ':'); i >= 0 {
+		epoch, version = version[:i], version[i+1:]
+	}
+	if i := strings.LastIndexByte(version, '-'); i >= 0 {
+		version, release = version[:i], version[i+1:]
+	}
+	return epoch, version, release
+}
+
+func compareRPMPart(a, b string) int { //nolint:gocyclo
+	ia, ib := 0, 0
+	for ia < len(a) || ib < len(b) {
+		for ia < len(a) && !isASCIIAlnum(a[ia]) && a[ia] != '~' && a[ia] != '^' {
+			ia++
+		}
+		for ib < len(b) && !isASCIIAlnum(b[ib]) && b[ib] != '~' && b[ib] != '^' {
+			ib++
+		}
+
+		if (ia < len(a) && a[ia] == '~') || (ib < len(b) && b[ib] == '~') {
+			if ia >= len(a) || a[ia] != '~' {
+				return 1
+			}
+			if ib >= len(b) || b[ib] != '~' {
+				return -1
+			}
+			ia++
+			ib++
+			continue
+		}
+		if (ia < len(a) && a[ia] == '^') || (ib < len(b) && b[ib] == '^') {
+			if ia >= len(a) {
+				return -1
+			}
+			if ib >= len(b) {
+				return 1
+			}
+			if a[ia] != '^' {
+				return 1
+			}
+			if b[ib] != '^' {
+				return -1
+			}
+			ia++
+			ib++
+			continue
+		}
+
+		if ia >= len(a) || ib >= len(b) {
+			return cmpInt(len(a)-ia, len(b)-ib)
+		}
+
+		aNum, bNum := isASCIIDigit(a[ia]), isASCIIDigit(b[ib])
+		if aNum != bNum {
+			if aNum {
+				return 1
+			}
+			return -1
+		}
+		ea, eb := ia, ib
+		if aNum {
+			for ea < len(a) && isASCIIDigit(a[ea]) {
+				ea++
+			}
+			for eb < len(b) && isASCIIDigit(b[eb]) {
+				eb++
+			}
+			if c := cmpNumStr(a[ia:ea], b[ib:eb]); c != 0 {
+				return c
+			}
+		} else {
+			for ea < len(a) && isASCIIAlpha(a[ea]) {
+				ea++
+			}
+			for eb < len(b) && isASCIIAlpha(b[eb]) {
+				eb++
+			}
+			if c := cmpString(a[ia:ea], b[ib:eb]); c != 0 {
+				return c
+			}
+		}
+		ia, ib = ea, eb
+	}
+	return 0
+}
+
+func compareIntDot(a, b string) int {
+	pa, pb := strings.Split(a, "."), strings.Split(b, ".")
+	for i := 0; i < len(pa) || i < len(pb); i++ {
+		var va, vb string
+		if i < len(pa) {
+			va = pa[i]
+		}
+		if i < len(pb) {
+			vb = pb[i]
+		}
+		if c := cmpNumStr(va, vb); c != 0 {
+			return c
+		}
+	}
+	return 0
+}
+
+func compareOpenSSL(a, b string) int {
+	va, okA := parseOpenSSLVersion(a)
+	vb, okB := parseOpenSSLVersion(b)
+	if !okA || !okB {
+		return CompareVersions(a, b)
+	}
+	if cmpNumStr(va.core[0], "3") >= 0 && cmpNumStr(vb.core[0], "3") >= 0 {
+		return compareSemver(a, b)
+	}
+	for i := range va.core {
+		if c := cmpNumStr(va.core[i], vb.core[i]); c != 0 {
+			return c
+		}
+	}
+	preA := strings.HasPrefix(va.patch, "-alpha") || strings.HasPrefix(va.patch, "-beta")
+	preB := strings.HasPrefix(vb.patch, "-alpha") || strings.HasPrefix(vb.patch, "-beta")
+	if preA != preB {
+		if preA {
+			return -1
+		}
+		return 1
+	}
+	return cmpString(va.patch, vb.patch)
+}
+
+type opensslVersion struct {
+	core  [3]string
+	patch string
+}
+
+func parseOpenSSLVersion(s string) (opensslVersion, bool) {
+	var v opensslVersion
+	parts := strings.SplitN(s, ".", 3) //nolint:mnd
+	if len(parts) != 3 || !isDigits(parts[0]) || !isDigits(parts[1]) {
+		return v, false
+	}
+	i := 0
+	for i < len(parts[2]) && isASCIIDigit(parts[2][i]) {
+		i++
+	}
+	if i == 0 {
+		return v, false
+	}
+	v.core = [3]string{parts[0], parts[1], parts[2][:i]}
+	v.patch = parts[2][i:]
+	return v, true
+}
+
+func isASCIIDigit(c byte) bool { return c >= '0' && c <= '9' }
+func isASCIIAlpha(c byte) bool { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') }
+func isASCIIAlnum(c byte) bool { return isASCIIDigit(c) || isASCIIAlpha(c) }

--- a/schemes_test.go
+++ b/schemes_test.go
@@ -125,6 +125,7 @@ func TestExistingSchemeComparatorEdges(t *testing.T) {
 		{"maven", "1.999999999999999999999999", "1.2", 1},
 		{"lexicographic", "10", "2", -1},
 		{"intdot", "1.0.0.1", "1.0.0", 1},
+		{"gentoo", "01", "1", 0},
 	}
 	for _, tt := range tests {
 		if got := CompareWithScheme(tt.a, tt.b, tt.scheme); got != tt.want {
@@ -238,6 +239,8 @@ func TestNativeRangeSchemeEdges(t *testing.T) {
 		{"gem", "~> 1.0, < 1.5", "1.4", true},
 		{"gem", "~> 1.0, < 1.5", "1.6", false},
 		{"cargo", ">=1.2.3, <2.0.0", "1.5.0", true},
+		{"nginx", "0.8.40+", "0.8.50", true},
+		{"nginx", "0.8.40+", "0.9.0", false},
 	}
 	for _, tt := range tests {
 		got, err := Satisfies(tt.version, tt.constraint, tt.scheme)

--- a/schemes_test.go
+++ b/schemes_test.go
@@ -161,6 +161,13 @@ func TestSchemeAwareSharedAPIs(t *testing.T) {
 	if !c.Satisfies("1.0.dev1") {
 		t.Error("scheme-aware constraint should order dev before alpha")
 	}
+	genericConstraint, err := ParseConstraint("<1.0a1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !genericConstraint.SatisfiesWithScheme("1.0.dev1", schemePyPI) {
+		t.Error("SatisfiesWithScheme should override generic constraint ordering")
+	}
 
 	interval := NewInterval("1.0.dev1", "1.0a1", true, false)
 	if interval.IsEmptyWithScheme("pypi") || !interval.ContainsWithScheme("1.0.dev2", "pypi") {

--- a/schemes_test.go
+++ b/schemes_test.go
@@ -1,0 +1,269 @@
+package vers
+
+import "testing"
+
+func TestSemverSchemeComparison(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0-2", "1.0.0-0a", -1},
+		{"1.0.0-999999999999999999999999", "1.0.0-1000000000000000000000000", -1},
+		{"999999999999999999999999.0.0", "888888888888888888888888.0.0", 1},
+		{"1.0.0+one", "1.0.0+two", 0},
+	}
+	for _, scheme := range []string{"semver", "npm", "cargo", "go", "golang", "hex", "elixir"} {
+		for _, tt := range tests {
+			if got := CompareWithScheme(tt.a, tt.b, scheme); got != tt.want {
+				t.Errorf("CompareWithScheme(%q, %q, %q) = %d, want %d", tt.a, tt.b, scheme, got, tt.want)
+			}
+		}
+	}
+	if got := Compare("999999999999999999999999.0.0", "888888888888888888888888.0.0"); got != 1 {
+		t.Errorf("Compare() with arbitrary-width SemVer components = %d, want 1", got)
+	}
+}
+
+func TestGemSchemeComparison(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "1.0.0.1", -1},
+		{"1.0.beta1", "1.0", -1},
+		{"1.0.a10", "1.0.a2", 1},
+		{"1.0-1", "1.0.pre.1", 0},
+		{"1.0", "1.0.0", 0},
+	}
+	for _, scheme := range []string{"gem", "rubygems"} {
+		for _, tt := range tests {
+			if got := CompareWithScheme(tt.a, tt.b, scheme); got != tt.want {
+				t.Errorf("CompareWithScheme(%q, %q, %q) = %d, want %d", tt.a, tt.b, scheme, got, tt.want)
+			}
+		}
+	}
+}
+
+func TestDebianSchemeComparison(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0~rc1", "1.0", -1},
+		{"1:1.0", "2.0", 1},
+		{"1.0", "1.0-0", 0},
+		{"1.0-1", "1.0-2", -1},
+		{"1.0~~", "1.0~", -1},
+		{"1.0+a", "1.0~a", 1},
+		{"0.0.0", "0:0.0.0", 0},
+		{"0:0.0.0-foo", "0.0.0-foo", 0},
+		{"1.2.3-1~deb7u1", "1.2.3-1", -1},
+		{"2.7.4+reloaded2-13ubuntu1", "2.7.4+reloaded2-13+deb9u1", -1},
+	}
+	for _, scheme := range []string{"deb", "debian"} {
+		for _, tt := range tests {
+			if got := CompareWithScheme(tt.a, tt.b, scheme); got != tt.want {
+				t.Errorf("CompareWithScheme(%q, %q, %q) = %d, want %d", tt.a, tt.b, scheme, got, tt.want)
+			}
+		}
+	}
+}
+
+func TestRPMSchemeComparison(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0~rc1", "1.0", -1},
+		{"1:1.0", "2.0", 1},
+		{"1.0", "1.0-1", -1},
+		{"2.0^20250611", "2.0", 1},
+		{"2.0^20250611", "2.0.1", -1},
+		{"1.xyz", "1.0", -1},
+		{"2.0.1a", "2.0.1", 1},
+		{"1.0p10", "1.0p2", 1},
+		{"1.01", "1.1", 0},
+		{"1.0", "1_0", 0},
+		{"1.0", "1.0+", 0},
+		{"2.0", "2.0.1", -1},
+		{"5.5p1", "5.5p2", -1},
+		{"5.5p1", "5.5p10", -1},
+		{"10xyz", "10.1xyz", -1},
+		{"xyz10", "xyz10.1", -1},
+		{"xyz.4", "8", -1},
+		{"6.0.rc1", "6.0", 1},
+		{"10b2", "10a1", 1},
+		{"1.0a", "1.0aa", -1},
+		{"10.0001", "10.0039", -1},
+		{"20101121", "20101122", -1},
+		{"a+", "a_", 0},
+		{"+", "_", 0},
+		{"1.0~rc1", "1.0~rc2", -1},
+		{"1.0~rc1~git123", "1.0~rc1", -1},
+		{"1.0^", "1.0", 1},
+		{"1.0^git1", "1.0^git2", -1},
+		{"1.0^git1", "1.01", -1},
+		{"1.0^20160101", "1.0.1", -1},
+		{"1.0^20160102", "1.0^20160101^git1", 1},
+		{"1.0~rc1^git1", "1.0~rc1", 1},
+		{"1.0^git1~pre", "1.0^git1", -1},
+	}
+	for _, tt := range tests {
+		if got := CompareWithScheme(tt.a, tt.b, "rpm"); got != tt.want {
+			t.Errorf("CompareWithScheme(%q, %q, rpm) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestExistingSchemeComparatorEdges(t *testing.T) {
+	tests := []struct {
+		scheme, a, b string
+		want         int
+	}{
+		{"nuget", "1.0.0-2", "1.0.0-0a", -1},
+		{"nuget", "1.0.0-999999999999999999999999", "1.0.0-1000000000000000000000000", -1},
+		{"maven", "1.999999999999999999999999", "1.2", 1},
+		{"lexicographic", "10", "2", -1},
+		{"intdot", "1.0.0.1", "1.0.0", 1},
+	}
+	for _, tt := range tests {
+		if got := CompareWithScheme(tt.a, tt.b, tt.scheme); got != tt.want {
+			t.Errorf("CompareWithScheme(%q, %q, %q) = %d, want %d", tt.a, tt.b, tt.scheme, got, tt.want)
+		}
+	}
+}
+
+func TestSchemeAwareSharedAPIs(t *testing.T) {
+	best, err := HighestSatisfying([]string{"1.0.dev1", "1.0a1"}, "vers:pypi/*", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if best != "1.0a1" {
+		t.Errorf("HighestSatisfying pypi VERS = %q, want 1.0a1", best)
+	}
+
+	r, err := Parse("vers:pypi/>=1.0.dev1|<1.0a1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := r.String(); got == "empty" {
+		t.Errorf("Range.String() = %q for a non-empty pypi range", got)
+	}
+	if got := ToVersString(r, "pypi"); got != "vers:pypi/>=1.0.dev1|<1.0a1" {
+		t.Errorf("ToVersString() = %q, want scheme-sorted constraints", got)
+	}
+
+	c, err := ParseConstraintWithScheme("<1.0a1", "pypi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.Satisfies("1.0.dev1") {
+		t.Error("scheme-aware constraint should order dev before alpha")
+	}
+
+	interval := NewInterval("1.0.dev1", "1.0a1", true, false)
+	if interval.IsEmptyWithScheme("pypi") || !interval.ContainsWithScheme("1.0.dev2", "pypi") {
+		t.Error("scheme-aware interval methods should use PEP 440 ordering")
+	}
+}
+
+func TestCheckedRangeAlgebraRejectsMixedSchemes(t *testing.T) {
+	pypi, _ := Parse("vers:pypi/>=1.0")
+	maven, _ := Parse("vers:maven/<2.0")
+	if _, err := pypi.UnionChecked(maven); err == nil {
+		t.Error("UnionChecked should reject different schemes")
+	}
+	if _, err := pypi.IntersectChecked(maven); err == nil {
+		t.Error("IntersectChecked should reject different schemes")
+	}
+
+	generic := NewRange([]Interval{GreaterThanInterval("1.0.dev1", true)})
+	typedBase, _ := Parse("vers:pypi/*")
+	typed, err := generic.IntersectChecked(typedBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if typed.Scheme != "pypi" || !typed.Contains("1.0a1") {
+		t.Error("checked range algebra should inherit the non-empty scheme")
+	}
+}
+
+func TestSchemeAwareValidationAndNormalization(t *testing.T) {
+	tests := []struct {
+		scheme, input, normalized string
+	}{
+		{"pypi", "01!02.0RC1", "1!2.0rc1"},
+		{"gem", "1.0.beta1", "1.0.beta1"},
+		{"deb", "1:2.3.4-1", "1:2.3.4-1"},
+		{"rpm", "1.0~rc1", "1.0~rc1"},
+		{"npm", "1.2", "1.2.0"},
+		{"go", "v1.2", "v1.2.0"},
+	}
+	for _, tt := range tests {
+		if !ValidWithScheme(tt.input, tt.scheme) {
+			t.Errorf("ValidWithScheme(%q, %q) = false", tt.input, tt.scheme)
+			continue
+		}
+		got, err := NormalizeWithScheme(tt.input, tt.scheme)
+		if err != nil {
+			t.Errorf("NormalizeWithScheme(%q, %q) error = %v", tt.input, tt.scheme, err)
+			continue
+		}
+		if got != tt.normalized {
+			t.Errorf("NormalizeWithScheme(%q, %q) = %q, want %q", tt.input, tt.scheme, got, tt.normalized)
+		}
+		if CompareWithScheme(got, tt.input, tt.scheme) != 0 {
+			t.Errorf("normalized %q is not equivalent to %q under %s", got, tt.input, tt.scheme)
+		}
+	}
+	if ValidWithScheme("x:1.0", "deb") {
+		t.Error("ValidWithScheme accepted a non-numeric Debian epoch")
+	}
+	if _, err := NormalizeWithScheme("x:1.0", "deb"); err == nil {
+		t.Error("NormalizeWithScheme accepted an invalid Debian version")
+	}
+}
+
+func TestNativeRangeSchemeEdges(t *testing.T) {
+	tests := []struct {
+		scheme, constraint, version string
+		want                        bool
+	}{
+		{"cargo", "1.2.3", "1.9.0", true},
+		{"cargo", "1.2.3", "2.0.0", false},
+		{"gem", "~> 1.0.beta1", "1.9", true},
+		{"gem", "~> 1.0.beta1", "2.0", false},
+		{"gem", "~> 1.0.0.beta1", "1.0.9", true},
+		{"gem", "~> 1.0.0.beta1", "1.1", false},
+		{"gem", "~> 1.0, < 1.5", "1.4", true},
+		{"gem", "~> 1.0, < 1.5", "1.6", false},
+		{"cargo", ">=1.2.3, <2.0.0", "1.5.0", true},
+	}
+	for _, tt := range tests {
+		got, err := Satisfies(tt.version, tt.constraint, tt.scheme)
+		if err != nil {
+			t.Errorf("Satisfies(%q, %q, %q) error = %v", tt.version, tt.constraint, tt.scheme, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("Satisfies(%q, %q, %q) = %v, want %v", tt.version, tt.constraint, tt.scheme, got, tt.want)
+		}
+	}
+}
+
+func TestOpenSSLLegacyPatchOrdering(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "1.0.0a", -1},
+		{"1.0.0-beta1", "1.0.0", -1},
+		{"1.0.0z", "3.0.0", -1},
+		{"3.0.0-rc1", "3.0.0", -1},
+	}
+	for _, tt := range tests {
+		if got := CompareWithScheme(tt.a, tt.b, "openssl"); got != tt.want {
+			t.Errorf("CompareWithScheme(%q, %q, openssl) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}

--- a/vers.go
+++ b/vers.go
@@ -45,8 +45,12 @@ func Parse(versURI string) (*Range, error) {
 //   - nuget: [1.0,2.0), (1.0,2.0]
 //   - cargo: ^1.2.3, ~1.2.3, >=1.0.0, <2.0.0
 //   - go: >=1.0.0, <2.0.0
+//   - hex/elixir: ~> 1.2, >= 1.0 and < 2.0
 //   - deb/debian: >= 1.0, << 2.0
 //   - rpm: >= 1.0, <= 2.0
+//   - conan: ^1.2, ~1.2, >1 <2, ||
+//   - openssl: exact versions, optionally comma-separated
+//   - nginx: 0.8.40+, 0.7.52-0.8.39
 func ParseNative(constraint string, scheme string) (*Range, error) {
 	return defaultParser.ParseNative(constraint, scheme)
 }
@@ -99,17 +103,26 @@ func HighestSatisfying(versions []string, constraint, scheme string) (string, er
 	if err != nil {
 		return "", err
 	}
+	effectiveScheme := scheme
+	if effectiveScheme == "" {
+		effectiveScheme = r.Scheme
+	}
 
 	var best string
 	for _, v := range versions {
 		if !r.Contains(v) {
 			continue
 		}
-		if best == "" || CompareWithScheme(v, best, scheme) > 0 {
+		if best == "" || CompareWithScheme(v, best, effectiveScheme) > 0 {
 			best = v
 		}
 	}
 	return best, nil
+}
+
+// ValidWithScheme checks whether a version is valid for the given scheme.
+func ValidWithScheme(version, scheme string) bool {
+	return validVersionForScheme(version, scheme)
 }
 
 // Valid checks if a version string is valid.
@@ -125,6 +138,12 @@ func Normalize(version string) (string, error) {
 		return "", err
 	}
 	return v.String(), nil
+}
+
+// NormalizeWithScheme normalizes a version without discarding scheme-specific
+// components. Schemes without a canonical text form are validated and trimmed.
+func NormalizeWithScheme(version, scheme string) (string, error) {
+	return normalizeVersionForScheme(version, scheme)
 }
 
 // Exact creates a range that matches only the specified version.

--- a/version.go
+++ b/version.go
@@ -260,6 +260,9 @@ func CompareVersions(a, b string) int {
 	if b == "" {
 		return 1
 	}
+	if SemanticVersionRegex.MatchString(a) && SemanticVersionRegex.MatchString(b) {
+		return compareSemver(a, b)
+	}
 
 	va, errA := ParseVersion(a)
 	vb, errB := ParseVersion(b)
@@ -300,14 +303,51 @@ func CompareWithScheme(a, b, scheme string) int {
 // compareFuncFor returns the version comparison function for a scheme.
 func compareFuncFor(scheme string) func(a, b string) int {
 	switch scheme {
+	case "semver", "npm", "cargo", "go", "golang", "hex", "elixir":
+		return compareSemver
+	case "gem", "rubygems":
+		return compareGem
+	case "deb", "debian":
+		return compareDebian
+	case "rpm":
+		return compareRPM
 	case "nuget": //nolint:goconst
 		return compareNuGet
 	case "maven":
 		return compareMaven
 	case "pypi": //nolint:goconst
 		return comparePyPI
+	case "lexicographic", "datetime":
+		return cmpString
+	case "intdot":
+		return compareIntDot
+	case "apk", "alpine", "gentoo":
+		return compareGentoo
+	case "alpm":
+		return compareALPM
+	case "conan":
+		return compareConan
+	case "openssl":
+		return compareOpenSSL
 	default:
 		return CompareVersions
+	}
+}
+
+func canonicalScheme(scheme string) string {
+	switch scheme {
+	case "rubygems":
+		return "gem"
+	case "debian":
+		return "deb"
+	case "golang":
+		return "go"
+	case "elixir":
+		return "hex"
+	case "alpine":
+		return "apk"
+	default:
+		return scheme
 	}
 }
 
@@ -319,11 +359,8 @@ func compareNuGet(a, b string) int {
 
 	// Compare numeric parts (up to 4)
 	for i := 0; i < 4; i++ {
-		if partsA.numeric[i] < partsB.numeric[i] {
-			return -1
-		}
-		if partsA.numeric[i] > partsB.numeric[i] {
-			return 1
+		if c := cmpNumStr(partsA.numeric[i], partsB.numeric[i]); c != 0 {
+			return c
 		}
 	}
 
@@ -344,7 +381,7 @@ func compareNuGet(a, b string) int {
 }
 
 type nugetVersion struct {
-	numeric    [4]int // major, minor, patch, revision
+	numeric    [4]string // major, minor, patch, revision
 	prerelease string
 }
 
@@ -365,61 +402,19 @@ func parseNuGetVersion(s string) nugetVersion {
 	// Parse numeric parts
 	parts := strings.Split(s, ".")
 	for i := 0; i < len(parts) && i < 4; i++ {
-		result.numeric[i], _ = strconv.Atoi(parts[i])
+		if isDigits(parts[i]) {
+			result.numeric[i] = parts[i]
+		}
 	}
 
 	return result
 }
 
 func compareNuGetPrerelease(a, b string) int {
-	// NuGet prerelease comparison: case-insensitive, dot-separated, numeric parts compared numerically
+	// NuGet prerelease comparison is SemVer 2 ordering, case-insensitive.
 	partsA := strings.Split(strings.ToLower(a), ".")
 	partsB := strings.Split(strings.ToLower(b), ".")
-
-	maxLen := len(partsA)
-	if len(partsB) > maxLen {
-		maxLen = len(partsB)
-	}
-
-	for i := 0; i < maxLen; i++ {
-		var partA, partB string
-		if i < len(partsA) {
-			partA = partsA[i]
-		}
-		if i < len(partsB) {
-			partB = partsB[i]
-		}
-
-		if partA == "" {
-			return -1
-		}
-		if partB == "" {
-			return 1
-		}
-
-		// Try numeric comparison
-		numA, errA := strconv.Atoi(partA)
-		numB, errB := strconv.Atoi(partB)
-
-		if errA == nil && errB == nil {
-			if numA < numB {
-				return -1
-			}
-			if numA > numB {
-				return 1
-			}
-		} else {
-			// String comparison (already lowercased)
-			if partA < partB {
-				return -1
-			}
-			if partA > partB {
-				return 1
-			}
-		}
-	}
-
-	return 0
+	return compareSemverPrerelease(partsA, partsB)
 }
 
 // compareMaven compares two Maven version strings.
@@ -493,7 +488,7 @@ func compareMavenDifferentLevels(a, b mavenComponent) int {
 
 func compareMavenSameLevel(a, b mavenComponent) int {
 	if a.isNumeric && b.isNumeric {
-		return cmpInt(a.numeric, b.numeric)
+		return cmpNumStr(a.numeric, b.numeric)
 	}
 	if a.isNumeric {
 		return 1 // numeric > any qualifier
@@ -542,11 +537,8 @@ func compareMavenToNull(comp mavenComponent) int {
 }
 
 func compareMavenNumericToNull(comp mavenComponent) int {
-	if comp.numeric == 0 {
+	if cmpNumStr(comp.numeric, "0") == 0 {
 		return 0
-	}
-	if comp.afterDash && comp.numeric < 0 {
-		return -1
 	}
 	return 1
 }
@@ -559,7 +551,7 @@ func compareMavenQualifierToNull(qualifier string) int {
 
 type mavenComponent struct {
 	isNumeric bool
-	numeric   int
+	numeric   string
 	qualifier string
 	isNull    bool
 	afterDash bool // true if this component came after a dash (or digit-letter transition)
@@ -603,9 +595,7 @@ func parseMavenVersion(s string) []mavenComponent {
 		// Check if next part is a digit (for single-letter qualifier normalization)
 		nextIsDigit := false
 		if i+1 < len(parts) {
-			if _, err := strconv.Atoi(parts[i+1]); err == nil {
-				nextIsDigit = true
-			}
+			nextIsDigit = isDigits(parts[i+1])
 		}
 		// Normalize qualifier aliases
 		normalized := normalizeMavenQualifierWithNext(part, nextIsDigit)
@@ -617,8 +607,8 @@ func parseMavenVersion(s string) []mavenComponent {
 		if i < len(afterDashFlags) {
 			afterDash = afterDashFlags[i]
 		}
-		if num, err := strconv.Atoi(normalized); err == nil {
-			result = append(result, mavenComponent{isNumeric: true, numeric: num, afterDash: afterDash})
+		if isDigits(normalized) {
+			result = append(result, mavenComponent{isNumeric: true, numeric: normalized, afterDash: afterDash})
 		} else {
 			result = append(result, mavenComponent{qualifier: normalized, afterDash: afterDash})
 		}
@@ -655,7 +645,7 @@ func normalizeMavenComponents(components []mavenComponent) []mavenComponent {
 	if firstSublistIdx > 0 {
 		// Trim trailing zeros from base (indices 0 to firstSublistIdx-1)
 		baseEnd := firstSublistIdx
-		for baseEnd > 1 && components[baseEnd-1].isNumeric && components[baseEnd-1].numeric == 0 {
+		for baseEnd > 1 && components[baseEnd-1].isNumeric && cmpNumStr(components[baseEnd-1].numeric, "0") == 0 {
 			baseEnd--
 		}
 		if baseEnd < firstSublistIdx {
@@ -669,7 +659,7 @@ func normalizeMavenComponents(components []mavenComponent) []mavenComponent {
 		// No sublist - just remove trailing zeros from the end
 		for len(components) > 0 {
 			last := components[len(components)-1]
-			if last.isNumeric && last.numeric == 0 {
+			if last.isNumeric && cmpNumStr(last.numeric, "0") == 0 {
 				components = components[:len(components)-1]
 			} else {
 				break

--- a/version.go
+++ b/version.go
@@ -8,6 +8,36 @@ import (
 	"sync"
 )
 
+const (
+	schemeALPM          = "alpm"
+	schemeAlpine        = "alpine"
+	schemeAPK           = "apk"
+	schemeCargo         = "cargo"
+	schemeConan         = "conan"
+	schemeDatetime      = "datetime"
+	schemeDeb           = "deb"
+	schemeDebian        = "debian"
+	schemeElixir        = "elixir"
+	schemeGem           = "gem"
+	schemeGentoo        = "gentoo"
+	schemeGo            = "go"
+	schemeGolang        = "golang"
+	schemeHex           = "hex"
+	schemeIntDot        = "intdot"
+	schemeLexicographic = "lexicographic"
+	schemeMaven         = "maven"
+	schemeNginx         = "nginx"
+	schemeNPM           = "npm"
+	schemeNuGet         = "nuget"
+	schemeOpenSSL       = "openssl"
+	schemePyPI          = "pypi"
+	schemeRPM           = "rpm"
+	schemeRubyGems      = "rubygems"
+	schemeSemVer        = "semver"
+	qualifierAlpha      = "alpha"
+	qualifierBeta       = "beta"
+)
+
 // SemanticVersionRegex matches semantic version strings (with optional v prefix).
 var SemanticVersionRegex = regexp.MustCompile(`^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([^+]+))?(?:\+(.+))?$`)
 
@@ -303,31 +333,35 @@ func CompareWithScheme(a, b, scheme string) int {
 // compareFuncFor returns the version comparison function for a scheme.
 func compareFuncFor(scheme string) func(a, b string) int {
 	switch scheme {
-	case "semver", "npm", "cargo", "go", "golang", "hex", "elixir":
+	case schemeSemVer, schemeNPM, schemeCargo, schemeGo, schemeGolang, schemeHex, schemeElixir, schemeNginx:
 		return compareSemver
-	case "gem", "rubygems":
+	case schemeGem, schemeRubyGems:
 		return compareGem
-	case "deb", "debian":
+	case schemeDeb, schemeDebian:
 		return compareDebian
-	case "rpm":
+	case schemeRPM:
 		return compareRPM
-	case "nuget": //nolint:goconst
+	case schemeNuGet:
 		return compareNuGet
-	case "maven":
+	case schemeMaven:
 		return compareMaven
-	case "pypi": //nolint:goconst
+	case schemePyPI:
 		return comparePyPI
-	case "lexicographic", "datetime":
+	case schemeLexicographic, schemeDatetime:
 		return cmpString
-	case "intdot":
+	case schemeIntDot:
 		return compareIntDot
-	case "apk", "alpine", "gentoo":
+	case schemeAPK, schemeAlpine:
+		// This covers the vendored Alpine cases, but is not a full apk-tools
+		// implementation; APK has additional VCS suffix and letter rules.
 		return compareGentoo
-	case "alpm":
+	case schemeGentoo:
+		return compareGentoo
+	case schemeALPM:
 		return compareALPM
-	case "conan":
+	case schemeConan:
 		return compareConan
-	case "openssl":
+	case schemeOpenSSL:
 		return compareOpenSSL
 	default:
 		return CompareVersions
@@ -336,16 +370,16 @@ func compareFuncFor(scheme string) func(a, b string) int {
 
 func canonicalScheme(scheme string) string {
 	switch scheme {
-	case "rubygems":
-		return "gem"
-	case "debian":
-		return "deb"
-	case "golang":
-		return "go"
-	case "elixir":
-		return "hex"
-	case "alpine":
-		return "apk"
+	case schemeRubyGems:
+		return schemeGem
+	case schemeDebian:
+		return schemeDeb
+	case schemeGolang:
+		return schemeGo
+	case schemeElixir:
+		return schemeHex
+	case schemeAlpine:
+		return schemeAPK
 	default:
 		return scheme
 	}
@@ -562,13 +596,13 @@ type mavenComponent struct {
 //
 //nolint:mnd,goconst
 var mavenQualifierOrder = map[string]int{
-	"alpha":     1,
-	"beta":      2,
-	"milestone": 3,
-	"rc":        4,
-	"snapshot":  5,
-	"":          6, // release
-	"sp":        7, // sp comes after release but before unknown qualifiers
+	qualifierAlpha: 1,
+	qualifierBeta:  2,
+	"milestone":    3,
+	"rc":           4,
+	"snapshot":     5,
+	"":             6, // release
+	"sp":           7, // sp comes after release but before unknown qualifiers
 }
 
 func getMavenQualifierOrder(q string) (int, bool) {
@@ -691,9 +725,9 @@ func normalizeMavenQualifierWithNext(q string, nextIsDigit bool) string {
 	if nextIsDigit && len(q) == 1 {
 		switch q {
 		case "a":
-			return "alpha"
+			return qualifierAlpha
 		case "b":
-			return "beta"
+			return qualifierBeta
 		case "m":
 			return "milestone"
 		}


### PR DESCRIPTION
Fixes #25.

Adds native version ordering for SemVer-based schemes, RubyGems, Debian, RPM, ALPM, Alpine/Gentoo, Conan, OpenSSL, lexicographic/datetime, and intdot. Scheme-aware behavior now carries through constraints, direct interval operations, range formatting and algebra, `HighestSatisfying`, VERS output sorting, validation, and normalization. Numeric components remain arbitrary-width in SemVer, NuGet, and Maven.

Also fixes Gem pessimistic ranges, Cargo bare and comma requirements, URL-decoded exact constraints, and native Conan, OpenSSL, and Nginx ranges. Every vendored VERS conformance suite is enabled, covering 2,682 native-range, containment, round-trip, equality, and comparison cases.